### PR TITLE
Remove Sized constraint on Readers and Writers

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -116,7 +116,7 @@ impl Default for Drawing {
 impl Drawing {
     /// Loads a `Drawing` from anything that implements the `Read` trait.
     pub fn load<T>(reader: &mut T) -> DxfResult<Drawing>
-        where T: Read {
+        where T: Read + ?Sized {
 
         let first_line = match read_line(reader) {
             Some(Ok(line)) => line,
@@ -152,14 +152,14 @@ impl Drawing {
     }
     /// Writes a `Drawing` to anything that implements the `Write` trait.
     pub fn save<T>(&self, writer: &mut T) -> DxfResult<()>
-        where T: Write {
+        where T: Write + ?Sized {
 
         let mut writer = CodePairWriter::new_ascii_writer(writer);
         self.save_internal(&mut writer)
     }
     /// Writes a `Drawing` as binary to anything that implements the `Write` trait.
     pub fn save_binary<T>(&self, writer: &mut T) -> DxfResult<()>
-        where T: Write {
+        where T: Write + ?Sized {
 
         let mut writer = CodePairWriter::new_binary_writer(writer);
         self.save_internal(&mut writer)
@@ -200,7 +200,7 @@ impl Drawing {
     }
     /// Writes a `Drawing` as DXB to anything that implements the `Write` trait.
     pub fn save_dxb<T>(&self, writer: &mut T) -> DxfResult<()>
-        where T: Write {
+        where T: Write + ?Sized {
 
         let mut writer = DxbWriter::new(writer);
         writer.write(self)

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -244,7 +244,7 @@ pub(crate) fn read_color_value(layer: &mut Layer, color: i16) -> Color {
 }
 
 pub(crate) fn read_line<T>(reader: &mut T) -> Option<DxfResult<String>>
-    where T: Read {
+    where T: Read + ?Sized {
 
     let mut result = String::new();
     let bytes = reader.bytes();
@@ -270,7 +270,7 @@ pub(crate) fn read_line<T>(reader: &mut T) -> Option<DxfResult<String>>
     Some(Ok(result))
 }
 
-pub(crate) fn read_u8<T: Read>(reader: &mut T) -> Option<io::Result<u8>> {
+pub(crate) fn read_u8<T: Read + ?Sized>(reader: &mut T) -> Option<io::Result<u8>> {
     let mut buf = [0];
     let size = match reader.read(&mut buf) {
         Ok(v) => v,


### PR DESCRIPTION
All of the top-level methods for saving/loading a DXF file take a `Read` or `Write` by reference, so you can relax the `Sized` bound. This means if you already have a `&mut Read` (i.e. trait object), you don't need to pass a reference to it to `Drawing::load()`. This adds an extra level of indirection and feels kinda odd.

My particular use case looks something like this:

```rust
fn load(&self, mut reader: &mut Read) -> Result<Drawing> {
    let raw = dxf::Drawing::load(&mut reader)    // actually passing &mut &mut Read here
        .chain_err(|| "Unable to load the DXF")?;

    ...
}
```