### PR TITLE
Updated dependencies, migrated to rust 2021, fixed clippy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## Unreleased
+
+- Update to Rust 2021 edition
+- Updated dependencies:
+  - `image` from 0.23 to 0.24
+  - `num` from 0.3 to 0.4
+  - `uuid` from 0.8 to 1.0
+
 ## 0.5.0
 
 - Update to Rust 2018 edition.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ixmilia/dxf-rs"
 readme = "README.md"
 keywords = ["AutoCAD", "CAD", "DXB", "DXF"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 targets = []
@@ -22,16 +22,16 @@ byteorder = "1.3.4"
 chrono = { version= "0.4.19", features = ["serde"] }
 encoding_rs = "0.8.26"
 enum_primitive = "0.1.1"
-image = "0.23.12"
+image = "0.24.1"
 itertools = "0.10.0"
-num = "0.3.1"
+num = "0.4.0"
 serde = { version = "1.*.*", optional = true }
 serde_derive = { version = "1.*.*", optional = true }
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.0.0", features = ["serde", "v4"] }
 
 [build-dependencies]
-xmltree = "0.8.0"
+xmltree = "0.10.3"
 
 [dev-dependencies]
-float-cmp = "0.8.0"
+float-cmp = "0.9.0"
 glob = "0.3.0"

--- a/build/build.rs
+++ b/build/build.rs
@@ -6,12 +6,14 @@ mod table_generator;
 mod test_helper_generator;
 mod xml_helpers;
 
-use std::env;
-use std::error::Error;
-use std::fmt::Debug;
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::Path;
+use std::{
+    env,
+    error::Error,
+    fmt::Debug,
+    fs::{self, File},
+    io::Write,
+    path::Path,
+};
 
 include!("../src/expected_type.rs");
 
@@ -37,7 +39,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut file = File::create(generated_dir.join("mod.rs")).ok().unwrap();
     file.write_all("// The contents of this file are automatically generated and should not be modified directly.  See the `build` directory.
 
-#[allow(clippy::all)]
 pub mod entities;
 pub mod header;
 pub mod objects;
@@ -57,6 +58,6 @@ pub mod tables;
 fn rerun_if_changed<S: Debug + ?Sized>(s: &S) {
     let s = format!("{:?}", s)
         .replace("\\\\", "/") // normalize directory separators
-        .replace("\"", ""); // ignore surrounding quotes
+        .replace('\"', ""); // ignore surrounding quotes
     println!("cargo:rerun-if-changed={}", s);
 }

--- a/build/entity_generator.rs
+++ b/build/entity_generator.rs
@@ -1,16 +1,12 @@
-extern crate xmltree;
-use self::xmltree::Element;
-
-use crate::ExpectedType;
-
-use crate::other_helpers::*;
-use crate::xml_helpers::*;
-
-use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufReader, Write};
-use std::iter::Iterator;
-use std::path::Path;
+use crate::{other_helpers::*, xml_helpers::*, ExpectedType};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{BufReader, Write},
+    iter::Iterator,
+    path::Path,
+};
+use xmltree::Element;
 
 pub fn generate_entities(generated_dir: &Path) {
     let element = load_xml();
@@ -43,7 +39,7 @@ use crate::enums::*;
 use crate::enum_primitive::FromPrimitive;
 use crate::objects::*;
 ".trim_start());
-    fun.push_str("\n");
+    fun.push('\n');
     generate_base_entity(&mut fun, &element);
     generate_entity_types(&mut fun, &element);
 
@@ -61,21 +57,21 @@ use crate::objects::*;
 }
 
 fn generate_base_entity(fun: &mut String, element: &Element) {
-    let entity = &element.children[0];
-    if name(&entity) != "Entity" {
+    let entity = first_child_element(element);
+    if name(entity) != "Entity" {
         panic!("Expected first entity to be 'Entity'.");
     }
     fun.push_str("#[derive(Debug, Clone)]\n");
     fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
     fun.push_str("pub struct EntityCommon {\n");
-    for c in &entity.children {
-        let t = if allow_multiples(&c) {
+    for c in child_elements(entity) {
+        let t = if allow_multiples(c) {
             format!("Vec<{}>", typ(c))
         } else {
             typ(c)
         };
-        if !comment(&c).is_empty() {
-            fun.push_str(&format!("    /// {}\n", comment(&c)));
+        if !comment(c).is_empty() {
+            fun.push_str(&format!("    /// {}\n", comment(c)));
         }
         match &*c.name {
             "Field" => {
@@ -86,7 +82,7 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
                 ));
             }
             "Pointer" => {
-                let typ = if allow_multiples(&c) {
+                let typ = if allow_multiples(c) {
                     "Vec<Handle>"
                 } else {
                     "Handle"
@@ -104,7 +100,7 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
     }
 
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
     fun.push_str("#[derive(Debug, Clone)]\n");
     fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
@@ -112,18 +108,18 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
     fun.push_str("    pub common: EntityCommon,\n");
     fun.push_str("    pub specific: EntityType,\n");
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
     fun.push_str("impl Default for EntityCommon {\n");
     fun.push_str("    fn default() -> EntityCommon {\n");
     fun.push_str("        EntityCommon {\n");
-    for c in &entity.children {
+    for c in child_elements(entity) {
         match &*c.name {
             "Field" => {
                 fun.push_str(&format!(
                     "            {name}: {val},\n",
                     name = name(c),
-                    val = default_value(&c)
+                    val = default_value(c)
                 ));
             }
             "Pointer" => {
@@ -140,12 +136,12 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
     fun.push_str("        }\n");
     fun.push_str("    }\n");
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
     fun.push_str("impl EntityCommon {\n");
 
     /////////////////////////////////////////////////////////////////// pointers
-    for p in &entity.children {
+    for p in child_elements(entity) {
         if p.name == "Pointer" {
             fun.push_str(&*get_methods_for_pointer_access(p));
         }
@@ -154,7 +150,7 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
     ////////////////////////////////////////////////////// apply_individual_pair
     fun.push_str("    pub(crate) fn apply_individual_pair(&mut self, pair: &CodePair, iter: &mut CodePairPutBack) -> DxfResult<()> {\n");
     fun.push_str("        match pair.code {\n");
-    for c in &entity.children {
+    for c in child_elements(entity) {
         if c.name == "Field" {
             if name(c) == "extension_data_groups" && code(c) == 102 {
                 fun.push_str("            extension_data::EXTENSION_DATA_GROUP => {\n");
@@ -164,10 +160,10 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
             } else if name(c) == "x_data" && code(c) == 1001 {
                 // handled below: x_data::XDATA_APPLICATIONNAME
             } else {
-                let read_fun = if allow_multiples(&c) {
-                    format!(".push({})", get_field_reader(&c))
+                let read_fun = if allow_multiples(c) {
+                    format!(".push({})", get_field_reader(c))
                 } else {
-                    format!(" = {}", get_field_reader(&c))
+                    format!(" = {}", get_field_reader(c))
                 };
                 fun.push_str(&format!(
                     "            {code} => {{ self.{field}{read_fun} }},\n",
@@ -179,7 +175,7 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
         } else if c.name == "Pointer" {
             fun.push_str(&format!(
                 "            {code} => {{ self.__{field}_handle = pair.as_handle()? }},\n",
-                code = code(&c),
+                code = code(c),
                 field = name(c)
             ));
         }
@@ -197,21 +193,21 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
     ///////////////////////////////////////////////////////////// add_code_pairs
     fun.push_str("    pub(crate) fn add_code_pairs(&self, pairs: &mut Vec<CodePair>, version: AcadVersion, write_handles: bool) {\n");
     fun.push_str("        let ent = self;\n");
-    for line in generate_write_code_pairs(&entity) {
+    for line in generate_write_code_pairs(entity) {
         fun.push_str(&format!("        {}\n", line));
     }
 
     fun.push_str("    }\n");
 
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 }
 
 fn generate_entity_types(fun: &mut String, element: &Element) {
     fun.push_str("#[derive(Clone, Debug, PartialEq)]\n");
     fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
     fun.push_str("pub enum EntityType {\n");
-    for c in &element.children {
+    for c in child_elements(element) {
         if c.name != "Entity" {
             panic!("expected top level entity");
         }
@@ -221,10 +217,10 @@ fn generate_entity_types(fun: &mut String, element: &Element) {
     }
 
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
     // individual structs
-    for c in &element.children {
+    for c in child_elements(element) {
         if c.name != "Entity" {
             panic!("expected top level entity");
         }
@@ -233,18 +229,18 @@ fn generate_entity_types(fun: &mut String, element: &Element) {
             fun.push_str("#[derive(Clone, Debug, PartialEq)]\n");
             fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
             fun.push_str(&format!("pub struct {typ} {{\n", typ = name(c)));
-            if base_class(&c) == "DimensionBase" {
+            if base_class(c) == "DimensionBase" {
                 fun.push_str("    pub dimension_base: DimensionBase,\n");
             }
-            for f in &c.children {
-                let t = if allow_multiples(&f) {
+            for f in child_elements(c) {
+                let t = if allow_multiples(f) {
                     format!("Vec<{}>", typ(f))
                 } else {
                     typ(f)
                 };
-                let is_private = name(f).starts_with("_");
-                if !comment(&f).is_empty() {
-                    fun.push_str(&format!("    /// {}\n", comment(&f)));
+                let is_private = name(f).starts_with('_');
+                if !comment(f).is_empty() {
+                    fun.push_str(&format!("    /// {}\n", comment(f)));
                 }
                 if is_private {
                     fun.push_str("    #[doc(hidden)]\n");
@@ -258,7 +254,7 @@ fn generate_entity_types(fun: &mut String, element: &Element) {
                         ));
                     }
                     "Pointer" => {
-                        let typ = if allow_multiples(&f) {
+                        let typ = if allow_multiples(f) {
                             "Vec<Handle>"
                         } else {
                             "Handle"
@@ -276,26 +272,26 @@ fn generate_entity_types(fun: &mut String, element: &Element) {
             }
 
             fun.push_str("}\n");
-            fun.push_str("\n");
+            fun.push('\n');
 
             // implementation
             fun.push_str(&format!("impl Default for {typ} {{\n", typ = name(c)));
             fun.push_str(&format!("    fn default() -> {typ} {{\n", typ = name(c)));
             fun.push_str(&format!("        {typ} {{\n", typ = name(c)));
-            if base_class(&c) == "DimensionBase" {
+            if base_class(c) == "DimensionBase" {
                 fun.push_str("            dimension_base: Default::default(),\n");
             }
-            for f in &c.children {
+            for f in child_elements(c) {
                 match &*f.name {
                     "Field" => {
                         fun.push_str(&format!(
                             "            {name}: {val},\n",
                             name = name(f),
-                            val = default_value(&f)
+                            val = default_value(f)
                         ));
                     }
                     "Pointer" => {
-                        let val = if allow_multiples(&f) {
+                        let val = if allow_multiples(f) {
                             "vec![]"
                         } else {
                             "Handle::empty()"
@@ -314,20 +310,20 @@ fn generate_entity_types(fun: &mut String, element: &Element) {
             fun.push_str("        }\n");
             fun.push_str("    }\n");
             fun.push_str("}\n");
-            fun.push_str("\n");
+            fun.push('\n');
 
-            generate_implementation(fun, &c);
+            generate_implementation(fun, c);
 
-            if name(&c) == "DimensionBase" {
+            if name(c) == "DimensionBase" {
                 fun.push_str("impl DimensionBase {\n");
                 fun.push_str("    pub(crate) fn add_code_pairs(&self, pairs: &mut Vec<CodePair>, version: AcadVersion) {\n");
                 fun.push_str("        let ent = self;\n");
-                for line in generate_write_code_pairs(&c) {
+                for line in generate_write_code_pairs(c) {
                     fun.push_str(&format!("        {}\n", line));
                 }
                 fun.push_str("    }\n");
                 fun.push_str("}\n");
-                fun.push_str("\n");
+                fun.push('\n');
             }
         }
     }
@@ -337,19 +333,19 @@ fn generate_implementation(fun: &mut String, element: &Element) {
     let mut implementation = String::new();
 
     // generate flags methods
-    for field in &element.children {
+    for field in child_elements(element) {
         if field.name == "Field" {
-            for flag in &field.children {
+            for flag in child_elements(field) {
                 if flag.name == "Flag" {
-                    let flag_name = name(&flag);
-                    let mask = attr(&flag, "Mask");
+                    let flag_name = name(flag);
+                    let mask = attr(flag, "Mask");
                     implementation.push_str(&format!(
                         "    pub fn get_{name}(&self) -> bool {{\n",
                         name = flag_name
                     ));
                     implementation.push_str(&format!(
                         "        self.{name} & {mask} != 0\n",
-                        name = name(&field),
+                        name = name(field),
                         mask = mask
                     ));
                     implementation.push_str("    }\n");
@@ -360,14 +356,14 @@ fn generate_implementation(fun: &mut String, element: &Element) {
                     implementation.push_str("        if val {\n");
                     implementation.push_str(&format!(
                         "            self.{name} |= {mask};\n",
-                        name = name(&field),
+                        name = name(field),
                         mask = mask
                     ));
                     implementation.push_str("        }\n");
                     implementation.push_str("        else {\n");
                     implementation.push_str(&format!(
                         "            self.{name} &= !{mask};\n",
-                        name = name(&field),
+                        name = name(field),
                         mask = mask
                     ));
                     implementation.push_str("        }\n");
@@ -378,17 +374,17 @@ fn generate_implementation(fun: &mut String, element: &Element) {
     }
 
     // generate pointer methods
-    for field in &element.children {
+    for field in child_elements(element) {
         if field.name == "Pointer" {
             implementation.push_str(&*get_methods_for_pointer_access(field));
         }
     }
 
     if !implementation.is_empty() {
-        fun.push_str(&format!("impl {typ} {{\n", typ = name(&element)));
+        fun.push_str(&format!("impl {typ} {{\n", typ = name(element)));
         fun.push_str(&implementation);
         fun.push_str("}\n");
-        fun.push_str("\n");
+        fun.push('\n');
     }
 }
 
@@ -397,23 +393,23 @@ fn generate_is_supported_on_version(fun: &mut String, element: &Element) {
         "    pub(crate) fn is_supported_on_version(&self, version: AcadVersion) -> bool {\n",
     );
     fun.push_str("        match self {\n");
-    for entity in &element.children {
-        if name(&entity) != "Entity" && name(&entity) != "DimensionBase" {
+    for entity in child_elements(element) {
+        if name(entity) != "Entity" && name(entity) != "DimensionBase" {
             let mut predicates = vec![];
-            if !min_version(&entity).is_empty() {
-                predicates.push(format!("version >= AcadVersion::{}", min_version(&entity)));
+            if !min_version(entity).is_empty() {
+                predicates.push(format!("version >= AcadVersion::{}", min_version(entity)));
             }
-            if !max_version(&entity).is_empty() {
-                predicates.push(format!("version <= AcadVersion::{}", max_version(&entity)));
+            if !max_version(entity).is_empty() {
+                predicates.push(format!("version <= AcadVersion::{}", max_version(entity)));
             }
-            let predicate = if predicates.len() == 0 {
+            let predicate = if predicates.is_empty() {
                 String::from("true")
             } else {
                 predicates.join(" && ")
             };
             fun.push_str(&format!(
                 "            &EntityType::{typ}(_) => {{ {predicate} }},\n",
-                typ = name(&entity),
+                typ = name(entity),
                 predicate = predicate
             ));
         }
@@ -425,13 +421,13 @@ fn generate_is_supported_on_version(fun: &mut String, element: &Element) {
 fn generate_type_string(fun: &mut String, element: &Element) {
     fun.push_str("    pub(crate) fn from_type_string(type_string: &str) -> Option<EntityType> {\n");
     fun.push_str("        match type_string {\n");
-    for c in &element.children {
+    for c in child_elements(element) {
         if name(c) != "Entity"
             && name(c) != "DimensionBase"
-            && base_class(&c) != "DimensionBase"
-            && !attr(&c, "TypeString").is_empty()
+            && base_class(c) != "DimensionBase"
+            && !attr(c, "TypeString").is_empty()
         {
-            let type_string = attr(&c, "TypeString");
+            let type_string = attr(c, "TypeString");
             let type_strings = type_string.split(',').collect::<Vec<_>>();
             for t in type_strings {
                 fun.push_str(&format!("            \"{type_string}\" => Some(EntityType::{typ}(Default::default())),\n", type_string=t, typ=name(c)));
@@ -445,9 +441,9 @@ fn generate_type_string(fun: &mut String, element: &Element) {
 
     fun.push_str("    pub(crate) fn to_type_string(&self) -> &str {\n");
     fun.push_str("        match self {\n");
-    for c in &element.children {
+    for c in child_elements(element) {
         // only write the first type string given
-        let type_string = attr(&c, "TypeString");
+        let type_string = attr(c, "TypeString");
         let type_strings = type_string.split(',').collect::<Vec<_>>();
         if name(c) != "Entity" && name(c) != "DimensionBase" && !type_string.is_empty() {
             fun.push_str(&format!(
@@ -466,13 +462,13 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
         "    pub(crate) fn try_apply_code_pair(&mut self, pair: &CodePair) -> DxfResult<bool> {\n",
     );
     fun.push_str("        match self {\n");
-    for c in &element.children {
+    for c in child_elements(element) {
         if c.name != "Entity" {
             panic!("expected top level entity");
         }
         if name(c) != "Entity" && name(c) != "DimensionBase" {
-            if generate_reader_function(&c) {
-                let ent = if name(&c) == "Seqend" { "_ent" } else { "ent" }; // SEQEND doesn't use this variable
+            if generate_reader_function(c) {
+                let ent = if name(c) == "Seqend" { "_ent" } else { "ent" }; // SEQEND doesn't use this variable
                 fun.push_str(&format!(
                     "            &mut EntityType::{typ}(ref mut {ent}) => {{\n",
                     typ = name(c),
@@ -480,23 +476,23 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
                 ));
                 fun.push_str("                match pair.code {\n");
                 let mut seen_codes = HashSet::new();
-                for f in &c.children {
-                    if f.name == "Field" && generate_reader(&f) {
-                        for (i, &cd) in codes(&f).iter().enumerate() {
+                for f in child_elements(c) {
+                    if f.name == "Field" && generate_reader(f) {
+                        for (i, &cd) in codes(f).iter().enumerate() {
                             if !seen_codes.contains(&cd) {
                                 seen_codes.insert(cd); // TODO: allow for duplicates
-                                let reader = get_field_reader(&f);
-                                let codes = codes(&f);
+                                let reader = get_field_reader(f);
+                                let codes = codes(f);
                                 let write_cmd = match codes.len() {
                                     1 => {
-                                        let read_fun = if allow_multiples(&f) {
+                                        let read_fun = if allow_multiples(f) {
                                             format!(".push({})", reader)
                                         } else {
                                             format!(" = {}", reader)
                                         };
                                         format!(
                                             "ent.{field}{read_fun}",
-                                            field = name(&f),
+                                            field = name(f),
                                             read_fun = read_fun
                                         )
                                     }
@@ -509,7 +505,7 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
                                         };
                                         format!(
                                             "ent.{field}.{suffix} = {reader}",
-                                            field = name(&f),
+                                            field = name(f),
                                             suffix = suffix,
                                             reader = reader
                                         )
@@ -523,10 +519,10 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
                             }
                         }
                     } else if f.name == "Pointer" {
-                        if allow_multiples(&f) {
-                            fun.push_str(&format!("                    {code} => {{ ent.__{field}_handle.push(pair.as_handle()?); }},\n", code=code(&f), field=name(&f)));
+                        if allow_multiples(f) {
+                            fun.push_str(&format!("                    {code} => {{ ent.__{field}_handle.push(pair.as_handle()?); }},\n", code=code(f), field=name(f)));
                         } else {
-                            fun.push_str(&format!("                    {code} => {{ ent.__{field}_handle = pair.as_handle()?; }},\n", code=code(&f), field=name(&f)));
+                            fun.push_str(&format!("                    {code} => {{ ent.__{field}_handle = pair.as_handle()?; }},\n", code=code(f), field=name(f)));
                         }
                     }
                 }
@@ -535,7 +531,7 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
                 fun.push_str("                }\n");
                 fun.push_str("            },\n");
             } else {
-                fun.push_str(&format!("            &mut EntityType::{typ}(_) => {{ panic!(\"this case should have been covered in a custom reader\"); }},\n", typ=name(&c)));
+                fun.push_str(&format!("            &mut EntityType::{typ}(_) => {{ panic!(\"this case should have been covered in a custom reader\"); }},\n", typ=name(c)));
             }
         }
     }
@@ -548,26 +544,26 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
 fn generate_get_code_pairs(fun: &mut String, element: &Element) {
     fun.push_str("    pub(crate) fn add_code_pairs(&self, pairs: &mut Vec<CodePair>, common: &EntityCommon, version: AcadVersion) {\n");
     fun.push_str("        match self {\n");
-    for entity in &element.children {
-        if name(&entity) != "Entity" && name(&entity) != "DimensionBase" {
-            if generate_writer_function(&entity) {
-                let ent = if name(&entity) == "Seqend" {
+    for entity in child_elements(element) {
+        if name(entity) != "Entity" && name(entity) != "DimensionBase" {
+            if generate_writer_function(entity) {
+                let ent = if name(entity) == "Seqend" {
                     "_ent"
                 } else {
                     "ent"
                 }; // SEQEND doesn't use this variable
                 fun.push_str(&format!(
                     "            &EntityType::{typ}(ref {ent}) => {{\n",
-                    typ = name(&entity),
+                    typ = name(entity),
                     ent = ent
                 ));
-                for line in generate_write_code_pairs(&entity) {
+                for line in generate_write_code_pairs(entity) {
                     fun.push_str(&format!("                {}\n", line));
                 }
 
                 fun.push_str("            },\n");
             } else {
-                fun.push_str(&format!("            &EntityType::{typ}(_) => {{ panic!(\"this case should have been covered in a custom writer\"); }},\n", typ=name(&entity)));
+                fun.push_str(&format!("            &EntityType::{typ}(_) => {{ panic!(\"this case should have been covered in a custom writer\"); }},\n", typ=name(entity)));
             }
         }
     }
@@ -576,8 +572,8 @@ fn generate_get_code_pairs(fun: &mut String, element: &Element) {
 }
 
 fn get_field_with_name<'a>(entity: &'a Element, field_name: &String) -> &'a Element {
-    for field in &entity.children {
-        if name(&field) == *field_name {
+    for field in child_elements(entity) {
+        if name(field) == *field_name {
             return field;
         }
     }
@@ -587,11 +583,11 @@ fn get_field_with_name<'a>(entity: &'a Element, field_name: &String) -> &'a Elem
 
 fn generate_write_code_pairs(entity: &Element) -> Vec<String> {
     let mut commands = vec![];
-    for f in &entity.children {
+    for f in child_elements(entity) {
         if f.name == "WriteOrder" {
             // order was specifically given to us
-            for write_command in &f.children {
-                for line in generate_write_code_pairs_for_write_order(&entity, &write_command) {
+            for write_command in child_elements(f) {
+                for line in generate_write_code_pairs_for_write_order(entity, write_command) {
                     commands.push(line);
                 }
             }
@@ -600,7 +596,7 @@ fn generate_write_code_pairs(entity: &Element) -> Vec<String> {
     }
 
     // no order given, use declaration order
-    let subclass = attr(&entity, "SubclassMarker");
+    let subclass = attr(entity, "SubclassMarker");
     if !subclass.is_empty() {
         commands.push("if version >= AcadVersion::R13 {".to_string());
         commands.push(format!(
@@ -609,11 +605,11 @@ fn generate_write_code_pairs(entity: &Element) -> Vec<String> {
         ));
         commands.push("}".to_string());
     }
-    for field in &entity.children {
-        if generate_writer(&field) {
+    for field in child_elements(entity) {
+        if generate_writer(field) {
             match &*field.name {
                 "Field" => {
-                    for line in get_write_lines_for_field(&field, vec![]) {
+                    for line in get_write_lines_for_field(field, vec![]) {
                         commands.push(line);
                     }
                 }
@@ -624,7 +620,7 @@ fn generate_write_code_pairs(entity: &Element) -> Vec<String> {
             }
         }
     }
-    return commands;
+    commands
 }
 
 fn generate_write_code_pairs_for_write_order(
@@ -635,70 +631,70 @@ fn generate_write_code_pairs_for_write_order(
     match &*write_command.name {
         "WriteField" => {
             let field_name = write_command.attributes.get("Field").unwrap();
-            let field = get_field_with_name(&entity, &field_name);
+            let field = get_field_with_name(entity, field_name);
             let normalized_field_name = if field.name == "Pointer" {
                 format!("__{}_handle", field_name)
             } else {
                 field_name.clone()
             };
-            let mut write_conditions = vec![attr(&write_command, "WriteCondition")];
-            if !attr(&write_command, "DontWriteIfValueIs").is_empty() {
+            let mut write_conditions = vec![attr(write_command, "WriteCondition")];
+            if !attr(write_command, "DontWriteIfValueIs").is_empty() {
                 write_conditions.push(format!(
                     "ent.{} != {}",
                     normalized_field_name,
-                    attr(&write_command, "DontWriteIfValueIs")
+                    attr(write_command, "DontWriteIfValueIs")
                 ));
             }
-            for line in get_write_lines_for_field(&field, write_conditions) {
+            for line in get_write_lines_for_field(field, write_conditions) {
                 commands.push(line);
             }
         }
         "WriteSpecificValue" => {
             let mut predicates = vec![];
-            if !min_version(&write_command).is_empty() {
+            if !min_version(write_command).is_empty() {
                 predicates.push(format!(
                     "version >= AcadVersion::{}",
-                    min_version(&write_command)
+                    min_version(write_command)
                 ));
             }
-            if !max_version(&write_command).is_empty() {
+            if !max_version(write_command).is_empty() {
                 predicates.push(format!(
                     "version <= AcadVersion::{}",
-                    max_version(&write_command)
+                    max_version(write_command)
                 ));
             }
-            if !attr(&write_command, "DontWriteIfValueIs").is_empty() {
+            if !attr(write_command, "DontWriteIfValueIs").is_empty() {
                 predicates.push(format!(
                     "{} != {}",
-                    attr(&write_command, "Value"),
-                    attr(&write_command, "DontWriteIfValueIs")
+                    attr(write_command, "Value"),
+                    attr(write_command, "DontWriteIfValueIs")
                 ));
             }
-            if !attr(&write_command, "WriteCondition").is_empty() {
-                predicates.push(attr(&write_command, "WriteCondition"));
+            if !attr(write_command, "WriteCondition").is_empty() {
+                predicates.push(attr(write_command, "WriteCondition"));
             }
-            let code = code(&write_command);
+            let code = code(write_command);
             let expected_type = ExpectedType::get_expected_type(code).unwrap();
             let typ = get_code_pair_type(&expected_type);
-            if predicates.len() > 0 {
+            if !predicates.is_empty() {
                 commands.push(format!("if {} {{", predicates.join(" && ")));
             }
-            let indent = if predicates.len() > 0 { "    " } else { "" };
+            let indent = if !predicates.is_empty() { "    " } else { "" };
             commands.push(format!(
                 "{indent}pairs.push(CodePair::new_{typ}({code}, {val}));",
                 indent = indent,
                 typ = typ,
                 code = code,
-                val = attr(&write_command, "Value")
+                val = attr(write_command, "Value")
             ));
-            if predicates.len() > 0 {
+            if !predicates.is_empty() {
                 commands.push(String::from("}"));
             }
         }
         "Foreach" => {
-            commands.push(format!("for item in &{} {{", attr(&write_command, "Field")));
-            for write_command in &write_command.children {
-                for line in generate_write_code_pairs_for_write_order(&entity, &write_command) {
+            commands.push(format!("for item in &{} {{", attr(write_command, "Field")));
+            for write_command in child_elements(write_command) {
+                for line in generate_write_code_pairs_for_write_order(entity, write_command) {
                     commands.push(format!("    {}", line));
                 }
             }
@@ -722,17 +718,17 @@ fn generate_write_code_pairs_for_write_order(
 fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> Vec<String> {
     let mut commands = vec![];
     let mut predicates = vec![];
-    if !min_version(&field).is_empty() {
-        predicates.push(format!("version >= AcadVersion::{}", min_version(&field)));
+    if !min_version(field).is_empty() {
+        predicates.push(format!("version >= AcadVersion::{}", min_version(field)));
     }
-    if !max_version(&field).is_empty() {
-        predicates.push(format!("version <= AcadVersion::{}", max_version(&field)));
+    if !max_version(field).is_empty() {
+        predicates.push(format!("version <= AcadVersion::{}", max_version(field)));
     }
-    if disable_writing_default(&field) {
+    if disable_writing_default(field) {
         predicates.push(format!(
             "ent.{field} != {default}",
-            field = name(&field),
-            default = default_value(&field)
+            field = name(field),
+            default = default_value(field)
         ));
     }
     for wc in write_conditions {
@@ -740,13 +736,13 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
             predicates.push(wc);
         }
     }
-    let indent = if predicates.len() == 0 { "" } else { "    " };
-    if predicates.len() > 0 {
+    let indent = if predicates.is_empty() { "" } else { "    " };
+    if !predicates.is_empty() {
         commands.push(format!("if {} {{", predicates.join(" && ")));
     }
 
-    if allow_multiples(&field) {
-        let expected_type = ExpectedType::get_expected_type(codes(&field)[0]).unwrap();
+    if allow_multiples(field) {
+        let expected_type = ExpectedType::get_expected_type(codes(field)[0]).unwrap();
         let val = if field.name == "Pointer" {
             "&v.as_string()"
         } else {
@@ -757,9 +753,9 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
             }
         };
         let normalized_field_name = if field.name == "Pointer" {
-            format!("__{}_handle", name(&field))
+            format!("__{}_handle", name(field))
         } else {
-            name(&field)
+            name(field)
         };
         let typ = get_code_pair_type(&expected_type);
         commands.push(format!(
@@ -771,12 +767,12 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
             "{indent}    pairs.push(CodePair::new_{typ}({code}, {val}));",
             indent = indent,
             typ = typ,
-            code = codes(&field)[0],
+            code = codes(field)[0],
             val = val
         ));
         commands.push(format!("{indent}}}", indent = indent));
     } else {
-        for command in get_code_pairs_for_field(&field) {
+        for command in get_code_pairs_for_field(field) {
             commands.push(format!(
                 "{indent}pairs.push({command});",
                 indent = indent,
@@ -785,7 +781,7 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
         }
     }
 
-    if predicates.len() > 0 {
+    if !predicates.is_empty() {
         commands.push(String::from("}"));
     }
 
@@ -793,9 +789,9 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
 }
 
 fn get_code_pairs_for_field(field: &Element) -> Vec<String> {
-    let codes = codes(&field);
+    let codes = codes(field);
     match codes.len() {
-        1 => vec![get_code_pair_for_field_and_code(codes[0], &field, None)],
+        1 => vec![get_code_pair_for_field_and_code(codes[0], field, None)],
         _ => {
             let mut pairs = vec![];
             for (i, &cd) in codes.iter().enumerate() {
@@ -805,7 +801,7 @@ fn get_code_pairs_for_field(field: &Element) -> Vec<String> {
                     2 => "z",
                     _ => panic!("unexpected multiple codes"),
                 };
-                pairs.push(get_code_pair_for_field_and_code(cd, &field, Some(suffix)));
+                pairs.push(get_code_pair_for_field_and_code(cd, field, Some(suffix)));
             }
             pairs
         }
@@ -815,7 +811,7 @@ fn get_code_pairs_for_field(field: &Element) -> Vec<String> {
 fn get_code_pair_for_field_and_code(code: i32, field: &Element, suffix: Option<&str>) -> String {
     let expected_type = ExpectedType::get_expected_type(code).unwrap();
     let typ = get_code_pair_type(&expected_type);
-    let mut write_converter = attr(&field, "WriteConverter");
+    let mut write_converter = attr(field, "WriteConverter");
     if field.name == "Pointer" {
         write_converter = String::from("&{}.as_string()");
     }
@@ -827,16 +823,16 @@ fn get_code_pair_for_field_and_code(code: i32, field: &Element, suffix: Option<&
         }
     }
     let normalized_field_name = if field.name == "Pointer" {
-        format!("__{}_handle", name(&field))
+        format!("__{}_handle", name(field))
     } else {
-        name(&field)
+        name(field)
     };
     let mut field_access = format!("ent.{field}", field = normalized_field_name);
     if let Some(suffix) = suffix {
         field_access = format!("{}.{}", field_access, suffix);
     }
     let writer = write_converter.replace("{}", &field_access);
-    if name(&field) == "handle" && code == 5 {
+    if name(field) == "handle" && code == 5 {
         String::from("CodePair::new_string(5, &self.handle.as_string())")
     } else {
         format!(
@@ -855,13 +851,13 @@ fn load_xml() -> Element {
 }
 
 fn generate_reader_function(element: &Element) -> bool {
-    attr(&element, "GenerateReaderFunction") != "false"
+    attr(element, "GenerateReaderFunction") != "false"
 }
 
 fn generate_writer_function(element: &Element) -> bool {
-    attr(&element, "GenerateWriterFunction") != "false"
+    attr(element, "GenerateWriterFunction") != "false"
 }
 
 fn base_class(element: &Element) -> String {
-    attr(&element, "BaseClass")
+    attr(element, "BaseClass")
 }

--- a/build/header_generator.rs
+++ b/build/header_generator.rs
@@ -1,16 +1,12 @@
-extern crate xmltree;
-use self::xmltree::Element;
-
-use crate::ExpectedType;
-
-use crate::other_helpers::*;
-use crate::xml_helpers::*;
-
-use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufReader, Write};
-use std::iter::Iterator;
-use std::path::Path;
+use crate::{other_helpers::*, xml_helpers::*, ExpectedType};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{BufReader, Write},
+    iter::Iterator,
+    path::Path,
+};
+use xmltree::Element;
 
 pub fn generate_header(generated_dir: &Path) {
     let element = load_xml();
@@ -62,28 +58,28 @@ fn generate_struct(fun: &mut String, element: &Element) {
     fun.push_str("/// Contains common properties for the DXF file.\n");
     fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
     fun.push_str("pub struct Header {\n");
-    for v in &element.children {
+    for v in child_elements(element) {
         let field_name = field(v);
         if !seen_fields.contains(&field_name) {
             seen_fields.insert(field_name.clone());
-            let mut comment = format!("The ${} header variable.  {}", name(&v), comment(&v));
-            if !min_version(&v).is_empty() {
-                comment.push_str(&format!("  Minimum AutoCAD version: {}.", min_version(&v)));
+            let mut comment = format!("The ${} header variable.  {}", name(v), comment(v));
+            if !min_version(v).is_empty() {
+                comment.push_str(&format!("  Minimum AutoCAD version: {}.", min_version(v)));
             }
-            if !max_version(&v).is_empty() {
-                comment.push_str(&format!("  Maximum AutoCAD version: {}.", max_version(&v)));
+            if !max_version(v).is_empty() {
+                comment.push_str(&format!("  Maximum AutoCAD version: {}.", max_version(v)));
             }
             fun.push_str(&format!("    /// {}\n", comment));
             fun.push_str(&format!(
                 "    pub {field}: {typ},\n",
-                field = field(&v),
-                typ = typ(&v)
+                field = field(v),
+                typ = typ(v)
             ));
         }
     }
 
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 }
 
 fn generate_default(fun: &mut String, element: &Element) {
@@ -91,14 +87,14 @@ fn generate_default(fun: &mut String, element: &Element) {
     fun.push_str("impl Default for Header {\n");
     fun.push_str("    fn default() -> Self {\n");
     fun.push_str("        Header {\n");
-    for v in &element.children {
-        if !seen_fields.contains(&field(&v)) {
-            seen_fields.insert(field(&v));
+    for v in child_elements(element) {
+        if !seen_fields.contains(&field(v)) {
+            seen_fields.insert(field(v));
             fun.push_str(&format!(
                 "            {field}: {default_value}, // ${name}\n",
-                field = field(&v),
-                default_value = default_value(&v),
-                name = name(&v)
+                field = field(v),
+                default_value = default_value(v),
+                name = name(v)
             ));
         }
     }
@@ -106,53 +102,53 @@ fn generate_default(fun: &mut String, element: &Element) {
     fun.push_str("        }\n");
     fun.push_str("    }\n");
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 }
 
 fn generate_flags(fun: &mut String, element: &Element) {
     let mut seen_fields = HashSet::new();
-    for v in &element.children {
-        if !seen_fields.contains(&field(&v)) {
-            seen_fields.insert(field(&v));
-            if v.children.len() > 0 {
-                fun.push_str(&format!("    // {} flags\n", field(&v)));
+    for v in child_elements(element) {
+        if !seen_fields.contains(&field(v)) {
+            seen_fields.insert(field(v));
+            if !v.children.is_empty() {
+                fun.push_str(&format!("    // {} flags\n", field(v)));
             }
-            for f in &v.children {
-                let mut comment = format!("{}", comment(&f));
-                if !min_version(&v).is_empty() {
-                    comment.push_str(&format!("  Minimum AutoCAD version: {}.", min_version(&v)));
+            for f in child_elements(v) {
+                let mut comment = comment(f);
+                if !min_version(v).is_empty() {
+                    comment.push_str(&format!("  Minimum AutoCAD version: {}.", min_version(v)));
                 }
-                if !max_version(&v).is_empty() {
-                    comment.push_str(&format!("  Maximum AutoCAD version: {}.", max_version(&v)));
+                if !max_version(v).is_empty() {
+                    comment.push_str(&format!("  Maximum AutoCAD version: {}.", max_version(v)));
                 }
                 fun.push_str(&format!("    /// {}\n", comment));
                 fun.push_str(&format!(
                     "    pub fn get_{flag}(&self) -> bool {{\n",
-                    flag = name(&f)
+                    flag = name(f)
                 ));
                 fun.push_str(&format!(
                     "        self.{field} & {mask} != 0\n",
-                    field = field(&v),
-                    mask = mask(&f)
+                    field = field(v),
+                    mask = mask(f)
                 ));
                 fun.push_str("    }\n");
                 fun.push_str(&format!("    /// {}\n", comment));
                 fun.push_str(&format!(
                     "    pub fn set_{flag}(&mut self, val: bool) {{\n",
-                    flag = name(&f)
+                    flag = name(f)
                 ));
-                fun.push_str(&format!("        if val {{\n"));
+                fun.push_str("        if val {\n");
                 fun.push_str(&format!(
                     "            self.{field} |= {mask};\n",
-                    field = field(&v),
-                    mask = mask(&f)
+                    field = field(v),
+                    mask = mask(f)
                 ));
                 fun.push_str("        }\n");
                 fun.push_str("        else {\n");
                 fun.push_str(&format!(
                     "            self.{field} &= !{mask};\n",
-                    field = field(&v),
-                    mask = mask(&f)
+                    field = field(v),
+                    mask = mask(f)
                 ));
                 fun.push_str("        }\n");
                 fun.push_str("    }\n");
@@ -165,14 +161,14 @@ fn generate_set_defaults(fun: &mut String, element: &Element) {
     let mut seen_fields = HashSet::new();
     fun.push_str("    /// Sets the default values on the header.\n");
     fun.push_str("    pub fn set_defaults(&mut self) {\n");
-    for v in &element.children {
-        if !seen_fields.contains(&field(&v)) {
-            seen_fields.insert(field(&v));
+    for v in child_elements(element) {
+        if !seen_fields.contains(&field(v)) {
+            seen_fields.insert(field(v));
             fun.push_str(&format!(
                 "        self.{field} = {default_value}; // ${name}\n",
-                field = field(&v),
-                default_value = default_value(&v),
-                name = name(&v)
+                field = field(v),
+                default_value = default_value(v),
+                name = name(v)
             ));
         }
     }
@@ -185,43 +181,41 @@ fn generate_set_header_value(fun: &mut String, element: &Element) {
     fun.push_str("    #[allow(clippy::cognitive_complexity)] // generated method\n");
     fun.push_str("    pub(crate) fn set_header_value(&mut self, variable: &str, pair: &CodePair) -> DxfResult<()> {\n");
     fun.push_str("        match variable {\n");
-    for v in &element.children {
-        if !seen_fields.contains(&field(&v)) {
-            seen_fields.insert(field(&v));
-            fun.push_str(&format!("            \"${name}\" => {{", name = name(&v)));
-            let variables_with_name: Vec<&Element> = element
-                .children
-                .iter()
-                .filter(|&vv| name(&vv) == name(&v))
+    for v in child_elements(element) {
+        if !seen_fields.contains(&field(v)) {
+            seen_fields.insert(field(v));
+            fun.push_str(&format!("            \"${name}\" => {{", name = name(v)));
+            let variables_with_name: Vec<&Element> = child_elements(element)
+                .filter(|&vv| name(vv) == name(v))
                 .collect();
             if variables_with_name.len() == 1 {
                 // only one variable with that name
-                fun.push_str(" ");
-                if code(&v) < 0 {
-                    fun.push_str(&format!("self.{field}.set(&pair)?;", field = field(&v)));
+                fun.push(' ');
+                if code(v) < 0 {
+                    fun.push_str(&format!("self.{field}.set(&pair)?;", field = field(v)));
                 } else {
-                    let read_cmd = get_read_command(&v);
+                    let read_cmd = get_read_command(v);
                     fun.push_str(&format!(
                         "verify_code(&pair, {code})?; self.{field} = {cmd};",
-                        code = code(&v),
-                        field = field(&v),
+                        code = code(v),
+                        field = field(v),
                         cmd = read_cmd
                     ));
                 }
 
-                fun.push_str(" ");
+                fun.push(' ');
             } else {
                 // multiple variables with that name
-                fun.push_str("\n");
+                fun.push('\n');
                 fun.push_str("                match pair.code {\n");
                 let expected_codes: Vec<i32> =
-                    variables_with_name.iter().map(|&vv| code(&vv)).collect();
+                    variables_with_name.iter().map(|&vv| code(vv)).collect();
                 for v in &variables_with_name {
-                    let read_cmd = get_read_command(&v);
+                    let read_cmd = get_read_command(v);
                     fun.push_str(&format!(
                         "                    {code} => self.{field} = {cmd},\n",
-                        code = code(&v),
-                        field = field(&v),
+                        code = code(v),
+                        field = field(v),
                         cmd = read_cmd
                     ));
                 }
@@ -235,22 +229,22 @@ fn generate_set_header_value(fun: &mut String, element: &Element) {
     }
     fun.push_str("            _ => (),\n");
     fun.push_str("        }\n");
-    fun.push_str("\n");
+    fun.push('\n');
     fun.push_str("        Ok(())\n");
     fun.push_str("    }\n");
 }
 
 fn get_read_command(element: &Element) -> String {
-    let reader_override = reader_override(&element);
+    let reader_override = reader_override(element);
     if !reader_override.is_empty() {
         reader_override
     } else {
         let expected_type = ExpectedType::get_expected_type(code(element)).unwrap();
         let reader_fun = get_reader_function(&expected_type);
-        let converter = if read_converter(&element).is_empty() {
+        let converter = if read_converter(element).is_empty() {
             String::from("{}")
         } else {
-            read_converter(&element).clone()
+            read_converter(element)
         };
         converter.replace("{}", &format!("pair.{}()?", reader_fun))
     }
@@ -259,21 +253,21 @@ fn get_read_command(element: &Element) -> String {
 fn generate_get_code_pairs_internal(fun: &mut String, element: &Element) {
     fun.push_str("    #[allow(clippy::cognitive_complexity)] // long function, no good way to simplify this\n");
     fun.push_str("    pub(crate) fn add_code_pairs_internal(&self, pairs: &mut Vec<CodePair>) {\n");
-    for v in &element.children {
-        if suppress_writing(&v) {
+    for v in child_elements(element) {
+        if suppress_writing(v) {
             continue;
         }
 
         // prepare writing predicate
         let mut parts = vec![];
-        if !min_version(&v).is_empty() {
-            parts.push(format!("self.version >= AcadVersion::{}", min_version(&v)));
+        if !min_version(v).is_empty() {
+            parts.push(format!("self.version >= AcadVersion::{}", min_version(v)));
         }
-        if !max_version(&v).is_empty() {
-            parts.push(format!("self.version <= AcadVersion::{}", max_version(&v)));
+        if !max_version(v).is_empty() {
+            parts.push(format!("self.version <= AcadVersion::{}", max_version(v)));
         }
-        if dont_write_default(&v) {
-            parts.push(format!("self.{} != {}", field(&v), default_value(&v)));
+        if dont_write_default(v) {
+            parts.push(format!("self.{} != {}", field(v), default_value(v)));
         }
         let indent = match parts.len() {
             0 => "",
@@ -281,43 +275,43 @@ fn generate_get_code_pairs_internal(fun: &mut String, element: &Element) {
         };
 
         // write the value
-        fun.push_str(&format!("        // ${}\n", name(&v)));
-        if parts.len() > 0 {
+        fun.push_str(&format!("        // ${}\n", name(v)));
+        if !parts.is_empty() {
             fun.push_str(&format!("        if {} {{\n", parts.join(" && ")));
         }
         fun.push_str(&format!(
             "        {indent}pairs.push(CodePair::new_str(9, \"${name}\"));\n",
-            name = name(&v),
+            name = name(v),
             indent = indent
         ));
-        let write_converter = if write_converter(&v).is_empty() {
+        let write_converter = if write_converter(v).is_empty() {
             String::from("{}")
         } else {
-            write_converter(&v).clone()
+            write_converter(v).clone()
         };
-        if code(&v) > 0 {
+        if code(v) > 0 {
             let expected_type =
-                get_code_pair_type(&ExpectedType::get_expected_type(code(&v)).unwrap());
-            let field_name = field(&v);
+                get_code_pair_type(&ExpectedType::get_expected_type(code(v)).unwrap());
+            let field_name = field(v);
             let value = format!("self.{}", field_name);
             let value = write_converter.replace("{}", &*value);
             fun.push_str(&format!(
                 "        {indent}pairs.push(CodePair::new_{typ}({code}, {value}));\n",
-                code = code(&v),
+                code = code(v),
                 value = value,
                 typ = expected_type,
                 indent = indent
             ));
         } else {
             // write a point or vector as it's components
-            for i in 0..code(&v).abs() {
+            for i in 0..code(v).abs() {
                 let (code, fld) = match i {
                     0 => (10, "x"),
                     1 => (20, "y"),
                     2 => (30, "z"),
                     _ => panic!("unexpected number of values"),
                 };
-                let value = write_converter.replace("{}", &format!("self.{}.{}", field(&v), fld));
+                let value = write_converter.replace("{}", &format!("self.{}.{}", field(v), fld));
                 fun.push_str(&format!(
                     "        {indent}pairs.push(CodePair::new_f64({code}, {value}));\n",
                     code = code,
@@ -326,12 +320,12 @@ fn generate_get_code_pairs_internal(fun: &mut String, element: &Element) {
                 ));
             }
         }
-        if parts.len() > 0 {
+        if !parts.is_empty() {
             fun.push_str("        }\n");
         }
 
         // newline between values
-        fun.push_str("\n");
+        fun.push('\n');
     }
 
     fun.push_str("    }\n");

--- a/build/object_generator.rs
+++ b/build/object_generator.rs
@@ -1,16 +1,12 @@
-extern crate xmltree;
-use self::xmltree::Element;
-
-use crate::ExpectedType;
-
-use crate::other_helpers::*;
-use crate::xml_helpers::*;
-
-use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufReader, Write};
-use std::iter::Iterator;
-use std::path::Path;
+use crate::{other_helpers::*, xml_helpers::*, ExpectedType};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{BufReader, Write},
+    iter::Iterator,
+    path::Path,
+};
+use xmltree::Element;
 
 pub fn generate_objects(generated_dir: &Path) {
     let element = load_xml();
@@ -52,7 +48,7 @@ use std::collections::HashMap;
 extern crate chrono;
 use self::chrono::{DateTime, Local};
 ".trim_start());
-    fun.push_str("\n");
+    fun.push('\n');
     generate_base_object(&mut fun, &element);
     generate_object_types(&mut fun, &element);
 
@@ -68,21 +64,21 @@ use self::chrono::{DateTime, Local};
 }
 
 fn generate_base_object(fun: &mut String, element: &Element) {
-    let object = &element.children[0];
-    if name(&object) != "Object" {
+    let object = first_child_element(element);
+    if name(object) != "Object" {
         panic!("Expected first object to be 'Object'.");
     }
     fun.push_str("#[derive(Clone, Debug)]\n");
     fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
     fun.push_str("pub struct ObjectCommon {\n");
-    for c in &object.children {
-        let t = if allow_multiples(&c) {
+    for c in child_elements(object) {
+        let t = if allow_multiples(c) {
             format!("Vec<{}>", typ(c))
         } else {
             typ(c)
         };
-        if !comment(&c).is_empty() {
-            fun.push_str(&format!("    /// {}\n", comment(&c)));
+        if !comment(c).is_empty() {
+            fun.push_str(&format!("    /// {}\n", comment(c)));
         }
         match &*c.name {
             "Field" => {
@@ -93,7 +89,7 @@ fn generate_base_object(fun: &mut String, element: &Element) {
                 ));
             }
             "Pointer" => {
-                let typ = if allow_multiples(&c) {
+                let typ = if allow_multiples(c) {
                     "Vec<Handle>"
                 } else {
                     "Handle"
@@ -111,7 +107,7 @@ fn generate_base_object(fun: &mut String, element: &Element) {
     }
 
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
     fun.push_str("#[derive(Clone, Debug)]\n");
     fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
@@ -119,18 +115,18 @@ fn generate_base_object(fun: &mut String, element: &Element) {
     fun.push_str("    pub common: ObjectCommon,\n");
     fun.push_str("    pub specific: ObjectType,\n");
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
     fun.push_str("impl Default for ObjectCommon {\n");
     fun.push_str("    fn default() -> ObjectCommon {\n");
     fun.push_str("        ObjectCommon {\n");
-    for c in &object.children {
+    for c in child_elements(object) {
         match &*c.name {
             "Field" => {
                 fun.push_str(&format!(
                     "            {name}: {val},\n",
                     name = name(c),
-                    val = default_value(&c)
+                    val = default_value(c)
                 ));
             }
             "Pointer" => {
@@ -147,12 +143,12 @@ fn generate_base_object(fun: &mut String, element: &Element) {
     fun.push_str("        }\n");
     fun.push_str("    }\n");
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
     fun.push_str("impl ObjectCommon {\n");
 
     /////////////////////////////////////////////////////////////////// pointers
-    for p in &object.children {
+    for p in child_elements(object) {
         if p.name == "Pointer" {
             fun.push_str(&*get_methods_for_pointer_access(p));
         }
@@ -161,7 +157,7 @@ fn generate_base_object(fun: &mut String, element: &Element) {
     ////////////////////////////////////////////////////// apply_individual_pair
     fun.push_str("    pub(crate) fn apply_individual_pair(&mut self, pair: &CodePair, iter: &mut CodePairPutBack) -> DxfResult<bool> {\n");
     fun.push_str("        match pair.code {\n");
-    for c in &object.children {
+    for c in child_elements(object) {
         if c.name == "Field" {
             if name(c) == "extension_data_groups" && code(c) == 102 {
                 fun.push_str("            extension_data::EXTENSION_DATA_GROUP => {\n");
@@ -171,10 +167,10 @@ fn generate_base_object(fun: &mut String, element: &Element) {
             } else if name(c) == "x_data" && code(c) == 1001 {
                 // handled below: x_data::XDATA_APPLICATIONNAME
             } else {
-                let read_fun = if allow_multiples(&c) {
-                    format!(".push({})", get_field_reader(&c))
+                let read_fun = if allow_multiples(c) {
+                    format!(".push({})", get_field_reader(c))
                 } else {
-                    format!(" = {}", get_field_reader(&c))
+                    format!(" = {}", get_field_reader(c))
                 };
                 fun.push_str(&format!(
                     "            {code} => {{ self.{field}{read_fun} }},\n",
@@ -186,7 +182,7 @@ fn generate_base_object(fun: &mut String, element: &Element) {
         } else if c.name == "Pointer" {
             fun.push_str(&format!(
                 "            {code} => {{ self.__{field}_handle = pair.as_handle()? }},\n",
-                code = code(&c),
+                code = code(c),
                 field = name(c)
             ));
         }
@@ -206,21 +202,21 @@ fn generate_base_object(fun: &mut String, element: &Element) {
         "    pub(crate) fn add_code_pairs(&self, pairs: &mut Vec<CodePair>, version: AcadVersion) {\n",
     );
     fun.push_str("        let obj = self;\n");
-    for line in generate_write_code_pairs(&object) {
+    for line in generate_write_code_pairs(object) {
         fun.push_str(&format!("        {}\n", line));
     }
 
     fun.push_str("    }\n");
 
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 }
 
 fn generate_object_types(fun: &mut String, element: &Element) {
     fun.push_str("#[derive(Clone, Debug, PartialEq)]\n");
     fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
     fun.push_str("pub enum ObjectType {\n");
-    for c in &element.children {
+    for c in child_elements(element) {
         if c.name != "Object" {
             panic!("expected top level object");
         }
@@ -230,10 +226,10 @@ fn generate_object_types(fun: &mut String, element: &Element) {
     }
 
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
     // individual structs
-    for c in &element.children {
+    for c in child_elements(element) {
         if c.name != "Object" {
             panic!("expected top level object");
         }
@@ -242,15 +238,15 @@ fn generate_object_types(fun: &mut String, element: &Element) {
             fun.push_str("#[derive(Clone, Debug, PartialEq)]\n");
             fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
             fun.push_str(&format!("pub struct {typ} {{\n", typ = name(c)));
-            for f in &c.children {
-                let t = if allow_multiples(&f) {
+            for f in child_elements(c) {
+                let t = if allow_multiples(f) {
                     format!("Vec<{}>", typ(f))
                 } else {
                     typ(f)
                 };
-                let is_private = name(f).starts_with("_");
-                if !comment(&f).is_empty() {
-                    fun.push_str(&format!("    /// {}\n", comment(&f)));
+                let is_private = name(f).starts_with('_');
+                if !comment(f).is_empty() {
+                    fun.push_str(&format!("    /// {}\n", comment(f)));
                 }
                 if is_private {
                     fun.push_str("    #[doc(hidden)]\n");
@@ -264,7 +260,7 @@ fn generate_object_types(fun: &mut String, element: &Element) {
                         ));
                     }
                     "Pointer" => {
-                        let typ = if allow_multiples(&f) {
+                        let typ = if allow_multiples(f) {
                             "Vec<Handle>"
                         } else {
                             "Handle"
@@ -282,23 +278,23 @@ fn generate_object_types(fun: &mut String, element: &Element) {
             }
 
             fun.push_str("}\n");
-            fun.push_str("\n");
+            fun.push('\n');
 
             // implementation
             fun.push_str(&format!("impl Default for {typ} {{\n", typ = name(c)));
             fun.push_str(&format!("    fn default() -> {typ} {{\n", typ = name(c)));
             fun.push_str(&format!("        {typ} {{\n", typ = name(c)));
-            for f in &c.children {
+            for f in child_elements(c) {
                 match &*f.name {
                     "Field" => {
                         fun.push_str(&format!(
                             "            {name}: {val},\n",
                             name = name(f),
-                            val = default_value(&f)
+                            val = default_value(f)
                         ));
                     }
                     "Pointer" => {
-                        let val = if allow_multiples(&f) {
+                        let val = if allow_multiples(f) {
                             "vec![]"
                         } else {
                             "Handle::empty()"
@@ -317,9 +313,9 @@ fn generate_object_types(fun: &mut String, element: &Element) {
             fun.push_str("        }\n");
             fun.push_str("    }\n");
             fun.push_str("}\n");
-            fun.push_str("\n");
+            fun.push('\n');
 
-            generate_implementation(fun, &c);
+            generate_implementation(fun, c);
         }
     }
 }
@@ -328,19 +324,19 @@ fn generate_implementation(fun: &mut String, element: &Element) {
     let mut implementation = String::new();
 
     // generate flags methods
-    for field in &element.children {
+    for field in child_elements(element) {
         if field.name == "Field" {
-            for flag in &field.children {
+            for flag in child_elements(field) {
                 if flag.name == "Flag" {
-                    let flag_name = name(&flag);
-                    let mask = attr(&flag, "Mask");
+                    let flag_name = name(flag);
+                    let mask = attr(flag, "Mask");
                     implementation.push_str(&format!(
                         "    pub fn get_{name}(&self) -> bool {{\n",
                         name = flag_name
                     ));
                     implementation.push_str(&format!(
                         "        self.{name} & {mask} != 0\n",
-                        name = name(&field),
+                        name = name(field),
                         mask = mask
                     ));
                     implementation.push_str("    }\n");
@@ -351,14 +347,14 @@ fn generate_implementation(fun: &mut String, element: &Element) {
                     implementation.push_str("        if val {\n");
                     implementation.push_str(&format!(
                         "            self.{name} |= {mask};\n",
-                        name = name(&field),
+                        name = name(field),
                         mask = mask
                     ));
                     implementation.push_str("        }\n");
                     implementation.push_str("        else {\n");
                     implementation.push_str(&format!(
                         "            self.{name} &= !{mask};\n",
-                        name = name(&field),
+                        name = name(field),
                         mask = mask
                     ));
                     implementation.push_str("        }\n");
@@ -369,17 +365,17 @@ fn generate_implementation(fun: &mut String, element: &Element) {
     }
 
     // generate pointer methods
-    for field in &element.children {
+    for field in child_elements(element) {
         if field.name == "Pointer" {
             implementation.push_str(&*get_methods_for_pointer_access(field));
         }
     }
 
     if !implementation.is_empty() {
-        fun.push_str(&format!("impl {typ} {{\n", typ = name(&element)));
+        fun.push_str(&format!("impl {typ} {{\n", typ = name(element)));
         fun.push_str(&implementation);
         fun.push_str("}\n");
-        fun.push_str("\n");
+        fun.push('\n');
     }
 }
 
@@ -388,23 +384,23 @@ fn generate_is_supported_on_version(fun: &mut String, element: &Element) {
         "    pub(crate) fn is_supported_on_version(&self, version: AcadVersion) -> bool {\n",
     );
     fun.push_str("        match self {\n");
-    for object in &element.children {
-        if name(&object) != "Object" {
+    for object in child_elements(element) {
+        if name(object) != "Object" {
             let mut predicates = vec![];
-            if !min_version(&object).is_empty() {
-                predicates.push(format!("version >= AcadVersion::{}", min_version(&object)));
+            if !min_version(object).is_empty() {
+                predicates.push(format!("version >= AcadVersion::{}", min_version(object)));
             }
-            if !max_version(&object).is_empty() {
-                predicates.push(format!("version <= AcadVersion::{}", max_version(&object)));
+            if !max_version(object).is_empty() {
+                predicates.push(format!("version <= AcadVersion::{}", max_version(object)));
             }
-            let predicate = if predicates.len() == 0 {
+            let predicate = if predicates.is_empty() {
                 String::from("true")
             } else {
                 predicates.join(" && ")
             };
             fun.push_str(&format!(
                 "            ObjectType::{typ}(_) => {{ {predicate} }},\n",
-                typ = name(&object),
+                typ = name(object),
                 predicate = predicate
             ));
         }
@@ -416,9 +412,9 @@ fn generate_is_supported_on_version(fun: &mut String, element: &Element) {
 fn generate_type_string(fun: &mut String, element: &Element) {
     fun.push_str("    pub(crate) fn from_type_string(type_string: &str) -> Option<ObjectType> {\n");
     fun.push_str("        match type_string {\n");
-    for c in &element.children {
-        if name(c) != "Object" && !attr(&c, "TypeString").is_empty() {
-            let type_string = attr(&c, "TypeString");
+    for c in child_elements(element) {
+        if name(c) != "Object" && !attr(c, "TypeString").is_empty() {
+            let type_string = attr(c, "TypeString");
             let type_strings = type_string.split(',').collect::<Vec<_>>();
             for t in type_strings {
                 fun.push_str(&format!("            \"{type_string}\" => Some(ObjectType::{typ}(Default::default())),\n", type_string=t, typ=name(c)));
@@ -432,9 +428,9 @@ fn generate_type_string(fun: &mut String, element: &Element) {
 
     fun.push_str("    pub(crate) fn to_type_string(&self) -> &str {\n");
     fun.push_str("        match *self {\n");
-    for c in &element.children {
+    for c in child_elements(element) {
         // only write the first type string given
-        let type_string = attr(&c, "TypeString");
+        let type_string = attr(c, "TypeString");
         let type_strings = type_string.split(',').collect::<Vec<_>>();
         if name(c) != "Object" && !type_string.is_empty() {
             fun.push_str(&format!(
@@ -455,13 +451,13 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
         "    pub(crate) fn try_apply_code_pair(&mut self, pair: &CodePair) -> DxfResult<bool> {\n",
     );
     fun.push_str("        match *self {\n");
-    for c in &element.children {
+    for c in child_elements(element) {
         if c.name != "Object" {
             panic!("expected top level object");
         }
         if name(c) != "Object" {
-            if generate_reader_function(&c) {
-                let obj = if name(&c) == "PlaceHolder" || name(&c) == "ObjectPointer" {
+            if generate_reader_function(c) {
+                let obj = if name(c) == "PlaceHolder" || name(c) == "ObjectPointer" {
                     "_obj"
                 } else {
                     "obj"
@@ -473,23 +469,23 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
                 ));
                 fun.push_str("                match pair.code {\n");
                 let mut seen_codes = HashSet::new();
-                for f in &c.children {
-                    if f.name == "Field" && generate_reader(&f) {
-                        for (i, &cd) in codes(&f).iter().enumerate() {
+                for f in child_elements(c) {
+                    if f.name == "Field" && generate_reader(f) {
+                        for (i, &cd) in codes(f).iter().enumerate() {
                             if !seen_codes.contains(&cd) {
                                 seen_codes.insert(cd); // TODO: allow for duplicates
-                                let reader = get_field_reader(&f);
-                                let codes = codes(&f);
+                                let reader = get_field_reader(f);
+                                let codes = codes(f);
                                 let write_cmd = match codes.len() {
                                     1 => {
-                                        let read_fun = if allow_multiples(&f) {
+                                        let read_fun = if allow_multiples(f) {
                                             format!(".push({})", reader)
                                         } else {
                                             format!(" = {}", reader)
                                         };
                                         format!(
                                             "obj.{field}{read_fun}",
-                                            field = name(&f),
+                                            field = name(f),
                                             read_fun = read_fun
                                         )
                                     }
@@ -502,7 +498,7 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
                                         };
                                         format!(
                                             "obj.{field}.{suffix} = {reader}",
-                                            field = name(&f),
+                                            field = name(f),
                                             suffix = suffix,
                                             reader = reader
                                         )
@@ -516,10 +512,10 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
                             }
                         }
                     } else if f.name == "Pointer" {
-                        if allow_multiples(&f) {
-                            fun.push_str(&format!("                    {code} => {{ obj.__{field}_handle.push(pair.as_handle()?); }},\n", code=code(&f), field=name(&f)));
+                        if allow_multiples(f) {
+                            fun.push_str(&format!("                    {code} => {{ obj.__{field}_handle.push(pair.as_handle()?); }},\n", code=code(f), field=name(f)));
                         } else {
-                            fun.push_str(&format!("                    {code} => {{ obj.__{field}_handle = pair.as_handle()?; }},\n", code=code(&f), field=name(&f)));
+                            fun.push_str(&format!("                    {code} => {{ obj.__{field}_handle = pair.as_handle()?; }},\n", code=code(f), field=name(f)));
                         }
                     }
                 }
@@ -529,12 +525,12 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
                 fun.push_str("            },\n");
             } else {
                 // ensure no read converters were specified (because they won't be used)
-                for f in &c.children {
-                    if f.name == "Field" && !attr(&f, "ReadConverter").is_empty() {
+                for f in child_elements(c) {
+                    if f.name == "Field" && !attr(f, "ReadConverter").is_empty() {
                         unused_readers.push(format!("{}.{}", name(c), name(f)));
                     }
                 }
-                fun.push_str(&format!("            ObjectType::{typ}(_) => {{ panic!(\"this case should have been covered in a custom reader\"); }},\n", typ=name(&c)));
+                fun.push_str(&format!("            ObjectType::{typ}(_) => {{ panic!(\"this case should have been covered in a custom reader\"); }},\n", typ=name(c)));
             }
         }
     }
@@ -543,9 +539,11 @@ fn generate_try_apply_code_pair(fun: &mut String, element: &Element) {
     fun.push_str("        Ok(true)\n");
     fun.push_str("    }\n");
 
-    if unused_readers.len() > 0 {
-        panic!("There were unused reader functions: {:?}", unused_readers);
-    }
+    assert!(
+        unused_readers.is_empty(),
+        "There were unused reader functions: {:?}",
+        unused_readers
+    );
 }
 
 fn generate_write(fun: &mut String, element: &Element) {
@@ -555,46 +553,48 @@ fn generate_write(fun: &mut String, element: &Element) {
         "    pub(crate) fn add_code_pairs(&self, pairs: &mut Vec<CodePair>, version: AcadVersion) {\n",
     );
     fun.push_str("        match *self {\n");
-    for object in &element.children {
-        if name(&object) != "Object" {
-            if generate_writer_function(&object) {
-                let obj = if name(&object) == "PlaceHolder" || name(&object) == "ObjectPointer" {
+    for object in child_elements(element) {
+        if name(object) != "Object" {
+            if generate_writer_function(object) {
+                let obj = if name(object) == "PlaceHolder" || name(object) == "ObjectPointer" {
                     "_obj"
                 } else {
                     "obj"
                 }; // ACDBPLACEHOLDER and OBJECT_PTR don't use this variable
                 fun.push_str(&format!(
                     "            ObjectType::{typ}(ref {obj}) => {{\n",
-                    typ = name(&object),
+                    typ = name(object),
                     obj = obj
                 ));
-                for line in generate_write_code_pairs(&object) {
+                for line in generate_write_code_pairs(object) {
                     fun.push_str(&format!("                {}\n", line));
                 }
 
                 fun.push_str("            },\n");
             } else {
                 // ensure no write converters were specified (because they won't be used)
-                for f in &element.children {
-                    if f.name == "Field" && !attr(&f, "WriteConverter").is_empty() {
+                for f in child_elements(element) {
+                    if f.name == "Field" && !attr(f, "WriteConverter").is_empty() {
                         unused_writers.push(format!("{}.{}", name(element), name(f)));
                     }
                 }
-                fun.push_str(&format!("            ObjectType::{typ}(_) => {{ panic!(\"this case should have been covered in a custom writer\"); }},\n", typ=name(&object)));
+                fun.push_str(&format!("            ObjectType::{typ}(_) => {{ panic!(\"this case should have been covered in a custom writer\"); }},\n", typ=name(object)));
             }
         }
     }
     fun.push_str("        }\n");
     fun.push_str("    }\n");
 
-    if unused_writers.len() > 0 {
-        panic!("There were unused writer functions: {:?}", unused_writers);
-    }
+    assert!(
+        unused_writers.is_empty(),
+        "There were unused writer functions: {:?}",
+        unused_writers
+    );
 }
 
 fn get_field_with_name<'a>(object: &'a Element, field_name: &String) -> &'a Element {
-    for field in &object.children {
-        if name(&field) == *field_name {
+    for field in child_elements(object) {
+        if name(field) == *field_name {
             return field;
         }
     }
@@ -604,11 +604,11 @@ fn get_field_with_name<'a>(object: &'a Element, field_name: &String) -> &'a Elem
 
 fn generate_write_code_pairs(object: &Element) -> Vec<String> {
     let mut commands = vec![];
-    for f in &object.children {
+    for f in child_elements(object) {
         if f.name == "WriteOrder" {
             // order was specifically given to us
-            for write_command in &f.children {
-                for line in generate_write_code_pairs_for_write_order(&object, &write_command) {
+            for write_command in child_elements(f) {
+                for line in generate_write_code_pairs_for_write_order(object, write_command) {
                     commands.push(line);
                 }
             }
@@ -617,18 +617,18 @@ fn generate_write_code_pairs(object: &Element) -> Vec<String> {
     }
 
     // no order given, use declaration order
-    let subclass = attr(&object, "SubclassMarker");
+    let subclass = attr(object, "SubclassMarker");
     if !subclass.is_empty() {
         commands.push(format!(
             "pairs.push(CodePair::new_str(100, \"{subclass}\"));",
             subclass = subclass
         ));
     }
-    for field in &object.children {
-        if generate_writer(&field) {
+    for field in child_elements(object) {
+        if generate_writer(field) {
             match &*field.name {
                 "Field" | "Pointer" => {
-                    for line in get_write_lines_for_field(&field, vec![]) {
+                    for line in get_write_lines_for_field(field, vec![]) {
                         commands.push(line);
                     }
                 }
@@ -636,7 +636,7 @@ fn generate_write_code_pairs(object: &Element) -> Vec<String> {
             }
         }
     }
-    return commands;
+    commands
 }
 
 fn generate_write_code_pairs_for_write_order(
@@ -647,67 +647,67 @@ fn generate_write_code_pairs_for_write_order(
     match &*write_command.name {
         "WriteField" => {
             let field_name = write_command.attributes.get("Field").unwrap();
-            let field = get_field_with_name(&object, &field_name);
+            let field = get_field_with_name(object, field_name);
             let normalized_field_name = if field.name == "Pointer" {
                 format!("__{}_handle", field_name)
             } else {
                 field_name.clone()
             };
-            let mut write_conditions = vec![attr(&write_command, "WriteCondition")];
-            if !attr(&write_command, "DontWriteIfValueIs").is_empty() {
+            let mut write_conditions = vec![attr(write_command, "WriteCondition")];
+            if !attr(write_command, "DontWriteIfValueIs").is_empty() {
                 write_conditions.push(format!(
                     "obj.{} != {}",
                     normalized_field_name,
-                    attr(&write_command, "DontWriteIfValueIs")
+                    attr(write_command, "DontWriteIfValueIs")
                 ));
             }
-            for line in get_write_lines_for_field(&field, write_conditions) {
+            for line in get_write_lines_for_field(field, write_conditions) {
                 commands.push(line);
             }
         }
         "WriteSpecificValue" => {
             let mut predicates = vec![];
-            if !min_version(&write_command).is_empty() {
+            if !min_version(write_command).is_empty() {
                 predicates.push(format!(
                     "version >= AcadVersion::{}",
-                    min_version(&write_command)
+                    min_version(write_command)
                 ));
             }
-            if !max_version(&write_command).is_empty() {
+            if !max_version(write_command).is_empty() {
                 predicates.push(format!(
                     "version <= AcadVersion::{}",
-                    max_version(&write_command)
+                    max_version(write_command)
                 ));
             }
-            if !attr(&write_command, "DontWriteIfValueIs").is_empty() {
+            if !attr(write_command, "DontWriteIfValueIs").is_empty() {
                 predicates.push(format!(
                     "{} != {}",
-                    attr(&write_command, "Value"),
-                    attr(&write_command, "DontWriteIfValueIs")
+                    attr(write_command, "Value"),
+                    attr(write_command, "DontWriteIfValueIs")
                 ));
             }
-            let code = code(&write_command);
+            let code = code(write_command);
             let expected_type = ExpectedType::get_expected_type(code).unwrap();
             let typ = get_code_pair_type(&expected_type);
-            if predicates.len() > 0 {
+            if !predicates.is_empty() {
                 commands.push(format!("if {} {{", predicates.join(" && ")));
             }
-            let indent = if predicates.len() > 0 { "    " } else { "" };
+            let indent = if !predicates.is_empty() { "    " } else { "" };
             commands.push(format!(
                 "{indent}pairs.push(CodePair::new_{typ}({code}, {val}));",
                 indent = indent,
                 typ = typ,
                 code = code,
-                val = attr(&write_command, "Value")
+                val = attr(write_command, "Value")
             ));
-            if predicates.len() > 0 {
+            if !predicates.is_empty() {
                 commands.push(String::from("}"));
             }
         }
         "Foreach" => {
-            commands.push(format!("for item in &{} {{", attr(&write_command, "Field")));
-            for write_command in &write_command.children {
-                for line in generate_write_code_pairs_for_write_order(&object, &write_command) {
+            commands.push(format!("for item in &{} {{", attr(write_command, "Field")));
+            for write_command in child_elements(write_command) {
+                for line in generate_write_code_pairs_for_write_order(object, write_command) {
                     commands.push(format!("    {}", line));
                 }
             }
@@ -731,17 +731,17 @@ fn generate_write_code_pairs_for_write_order(
 fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> Vec<String> {
     let mut commands = vec![];
     let mut predicates = vec![];
-    if !min_version(&field).is_empty() {
-        predicates.push(format!("version >= AcadVersion::{}", min_version(&field)));
+    if !min_version(field).is_empty() {
+        predicates.push(format!("version >= AcadVersion::{}", min_version(field)));
     }
-    if !max_version(&field).is_empty() {
-        predicates.push(format!("version <= AcadVersion::{}", max_version(&field)));
+    if !max_version(field).is_empty() {
+        predicates.push(format!("version <= AcadVersion::{}", max_version(field)));
     }
-    if disable_writing_default(&field) {
+    if disable_writing_default(field) {
         predicates.push(format!(
             "obj.{field} != {default}",
-            field = name(&field),
-            default = default_value(&field)
+            field = name(field),
+            default = default_value(field)
         ));
     }
     for wc in write_conditions {
@@ -749,26 +749,26 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
             predicates.push(wc);
         }
     }
-    let indent = if predicates.len() == 0 { "" } else { "    " };
-    if predicates.len() > 0 {
+    let indent = if predicates.is_empty() { "" } else { "    " };
+    if !predicates.is_empty() {
         commands.push(format!("if {} {{", predicates.join(" && ")));
     }
 
-    if allow_multiples(&field) {
-        let expected_type = ExpectedType::get_expected_type(codes(&field)[0]).unwrap();
+    if allow_multiples(field) {
+        let expected_type = ExpectedType::get_expected_type(codes(field)[0]).unwrap();
         let val = match (&*field.name, &expected_type) {
             ("Pointer", _) => "*v",
             (_, &ExpectedType::Str) => "&v",
             (_, &ExpectedType::Binary) => "v.clone()",
             _ => "*v",
         };
-        let write_converter = get_write_converter(&field);
+        let write_converter = get_write_converter(field);
         let to_write = write_converter.replace("{}", val);
         let typ = get_code_pair_type(&expected_type);
         let normalized_field_name = if field.name == "Pointer" {
-            format!("__{}_handle", name(&field))
+            format!("__{}_handle", name(field))
         } else {
-            name(&field)
+            name(field)
         };
         commands.push(format!(
             "{indent}for v in &obj.{field} {{",
@@ -779,12 +779,12 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
             "{indent}    pairs.push(CodePair::new_{typ}({code}, {to_write}));",
             indent = indent,
             typ = typ,
-            code = codes(&field)[0],
+            code = codes(field)[0],
             to_write = to_write
         ));
         commands.push(format!("{indent}}}", indent = indent));
     } else {
-        for command in get_code_pairs_for_field(&field) {
+        for command in get_code_pairs_for_field(field) {
             commands.push(format!(
                 "{indent}pairs.push({command});",
                 indent = indent,
@@ -793,7 +793,7 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
         }
     }
 
-    if predicates.len() > 0 {
+    if !predicates.is_empty() {
         commands.push(String::from("}"));
     }
 
@@ -801,9 +801,9 @@ fn get_write_lines_for_field(field: &Element, write_conditions: Vec<String>) -> 
 }
 
 fn get_code_pairs_for_field(field: &Element) -> Vec<String> {
-    let codes = codes(&field);
+    let codes = codes(field);
     match codes.len() {
-        1 => vec![get_code_pair_for_field_and_code(codes[0], &field, None)],
+        1 => vec![get_code_pair_for_field_and_code(codes[0], field, None)],
         _ => {
             let mut pairs = vec![];
             for (i, &cd) in codes.iter().enumerate() {
@@ -813,7 +813,7 @@ fn get_code_pairs_for_field(field: &Element) -> Vec<String> {
                     2 => "z",
                     _ => panic!("unexpected multiple codes"),
                 };
-                pairs.push(get_code_pair_for_field_and_code(cd, &field, Some(suffix)));
+                pairs.push(get_code_pair_for_field_and_code(cd, field, Some(suffix)));
             }
             pairs
         }
@@ -821,14 +821,14 @@ fn get_code_pairs_for_field(field: &Element) -> Vec<String> {
 }
 
 fn get_write_converter(field: &Element) -> String {
-    let code = codes(&field)[0];
-    get_write_converter_with_code(code, &field)
+    let code = codes(field)[0];
+    get_write_converter_with_code(code, field)
 }
 
 fn get_write_converter_with_code(code: i32, field: &Element) -> String {
     let expected_type = ExpectedType::get_expected_type(code).unwrap();
     let typ = get_code_pair_type(&expected_type);
-    let mut write_converter = attr(&field, "WriteConverter");
+    let mut write_converter = attr(field, "WriteConverter");
     if field.name == "Pointer" {
         write_converter = String::from("&{}.as_string()");
     }
@@ -846,18 +846,18 @@ fn get_write_converter_with_code(code: i32, field: &Element) -> String {
 fn get_code_pair_for_field_and_code(code: i32, field: &Element, suffix: Option<&str>) -> String {
     let expected_type = ExpectedType::get_expected_type(code).unwrap();
     let typ = get_code_pair_type(&expected_type);
-    let write_converter = get_write_converter_with_code(code, &field);
+    let write_converter = get_write_converter_with_code(code, field);
     let normalized_field_name = if field.name == "Pointer" {
-        format!("__{}_handle", name(&field))
+        format!("__{}_handle", name(field))
     } else {
-        name(&field)
+        name(field)
     };
     let mut field_access = format!("obj.{field}", field = normalized_field_name);
     if let Some(suffix) = suffix {
         field_access = format!("{}.{}", field_access, suffix);
     }
     let writer = write_converter.replace("{}", &field_access);
-    if name(&field) == "handle" && code == 5 {
+    if name(field) == "handle" && code == 5 {
         String::from("CodePair::new_string(5, &self.handle.as_string())")
     } else {
         format!(
@@ -876,9 +876,9 @@ fn load_xml() -> Element {
 }
 
 fn generate_reader_function(element: &Element) -> bool {
-    attr(&element, "GenerateReaderFunction") != "false"
+    attr(element, "GenerateReaderFunction") != "false"
 }
 
 fn generate_writer_function(element: &Element) -> bool {
-    attr(&element, "GenerateWriterFunction") != "false"
+    attr(element, "GenerateWriterFunction") != "false"
 }

--- a/build/other_helpers.rs
+++ b/build/other_helpers.rs
@@ -2,24 +2,24 @@ use crate::ExpectedType;
 
 pub fn get_reader_function(typ: &ExpectedType) -> &str {
     match typ {
-        &ExpectedType::Boolean => "assert_bool",
-        &ExpectedType::Integer => "assert_i32",
-        &ExpectedType::Long => "assert_i64",
-        &ExpectedType::Short => "assert_i16",
-        &ExpectedType::Double => "assert_f64",
-        &ExpectedType::Str => "assert_string",
-        &ExpectedType::Binary => "assert_binary",
+        ExpectedType::Boolean => "assert_bool",
+        ExpectedType::Integer => "assert_i32",
+        ExpectedType::Long => "assert_i64",
+        ExpectedType::Short => "assert_i16",
+        ExpectedType::Double => "assert_f64",
+        ExpectedType::Str => "assert_string",
+        ExpectedType::Binary => "assert_binary",
     }
 }
 
 pub fn get_code_pair_type(typ: &ExpectedType) -> String {
     match typ {
-        &ExpectedType::Boolean => String::from("bool"),
-        &ExpectedType::Integer => String::from("i32"),
-        &ExpectedType::Long => String::from("i64"),
-        &ExpectedType::Short => String::from("i16"),
-        &ExpectedType::Double => String::from("f64"),
-        &ExpectedType::Str => String::from("string"),
-        &ExpectedType::Binary => String::from("binary"),
+        ExpectedType::Boolean => String::from("bool"),
+        ExpectedType::Integer => String::from("i32"),
+        ExpectedType::Long => String::from("i64"),
+        ExpectedType::Short => String::from("i16"),
+        ExpectedType::Double => String::from("f64"),
+        ExpectedType::Str => String::from("string"),
+        ExpectedType::Binary => String::from("binary"),
     }
 }

--- a/build/table_generator.rs
+++ b/build/table_generator.rs
@@ -1,23 +1,17 @@
-extern crate xmltree;
-use self::xmltree::Element;
-
-use crate::ExpectedType;
-
-use crate::other_helpers::*;
-use crate::xml_helpers::*;
-
-use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufReader, Write};
-use std::path::Path;
+use crate::{other_helpers::*, xml_helpers::*, ExpectedType};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{BufReader, Write},
+    path::Path,
+};
+use xmltree::Element;
 
 pub fn generate_tables(generated_dir: &Path) {
     let element = load_xml();
     let mut fun = String::new();
     fun.push_str("
 // The contents of this file are automatically generated and should not be modified directly.  See the `build` directory.
-
-extern crate itertools;
 
 use crate::{
     CodePair,
@@ -43,7 +37,7 @@ use crate::x_data;
 use crate::enums::*;
 use crate::enum_primitive::FromPrimitive;
 ".trim_start());
-    fun.push_str("\n");
+    fun.push('\n');
     generate_table_items(&mut fun, &element);
     generate_table_reader(&mut fun, &element);
     generate_table_writer(&mut fun, &element);
@@ -53,35 +47,35 @@ use crate::enum_primitive::FromPrimitive;
 }
 
 fn generate_table_items(fun: &mut String, element: &Element) {
-    for table in &element.children {
+    for table in child_elements(element) {
         let mut seen_fields = HashSet::new();
-        let table_item = &table.children[0];
+        let table_item = first_child_element(table);
         fun.push_str("#[derive(Debug)]\n");
         fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
-        fun.push_str(&format!("pub struct {name} {{\n", name = name(&table_item)));
+        fun.push_str(&format!("pub struct {name} {{\n", name = name(table_item)));
         fun.push_str("    pub name: String,\n");
         fun.push_str("    pub handle: Handle,\n");
         fun.push_str("    #[doc(hidden)]\n");
         fun.push_str("    pub __owner_handle: Handle,\n");
         fun.push_str("    pub extension_data_groups: Vec<ExtensionGroup>,\n");
         fun.push_str("    pub x_data: Vec<XData>,\n");
-        for field in &table_item.children {
+        for field in child_elements(table_item) {
             let name = if field.name == "Pointer" {
-                format!("__{}_handle", name(&field))
+                format!("__{}_handle", name(field))
             } else {
-                name(&field)
+                name(field)
             };
             if !seen_fields.contains(&name) {
                 seen_fields.insert(name.clone());
                 let mut typ = if field.name == "Pointer" {
                     String::from("Handle")
                 } else {
-                    attr(&field, "Type")
+                    attr(field, "Type")
                 };
-                if allow_multiples(&field) {
+                if allow_multiples(field) {
                     typ = format!("Vec<{}>", typ);
                 }
-                let is_private = name.starts_with("_");
+                let is_private = name.starts_with('_');
                 if is_private {
                     fun.push_str("    #[doc(hidden)]\n");
                 }
@@ -89,32 +83,32 @@ fn generate_table_items(fun: &mut String, element: &Element) {
             }
         }
         fun.push_str("}\n");
-        fun.push_str("\n");
+        fun.push('\n');
 
         seen_fields.clear();
         fun.push_str(&format!(
             "impl Default for {name} {{\n",
-            name = name(&table_item)
+            name = name(table_item)
         ));
         fun.push_str("    fn default() -> Self {\n");
-        fun.push_str(&format!("        {name} {{\n", name = name(&table_item)));
+        fun.push_str(&format!("        {name} {{\n", name = name(table_item)));
         fun.push_str("            name: String::new(),\n");
         fun.push_str("            handle: Handle::empty(),\n");
         fun.push_str("            __owner_handle: Handle::empty(),\n");
         fun.push_str("            extension_data_groups: vec![],\n");
         fun.push_str("            x_data: vec![],\n");
-        for field in &table_item.children {
+        for field in child_elements(table_item) {
             let name = if field.name == "Pointer" {
-                format!("__{}_handle", name(&field))
+                format!("__{}_handle", name(field))
             } else {
-                name(&field)
+                name(field)
             };
             if !seen_fields.contains(&name) {
                 seen_fields.insert(name.clone());
-                let default_value = match (&*field.name, allow_multiples(&field)) {
+                let default_value = match (&*field.name, allow_multiples(field)) {
                     ("Pointer", true) => String::from("vec![]"),
                     ("Pointer", false) => String::from("Handle::empty()"),
-                    (_, _) => attr(&field, "DefaultValue"),
+                    (_, _) => attr(field, "DefaultValue"),
                 };
                 fun.push_str(&format!(
                     "            {field}: {default_value},\n",
@@ -127,9 +121,9 @@ fn generate_table_items(fun: &mut String, element: &Element) {
         fun.push_str("        }\n");
         fun.push_str("    }\n");
         fun.push_str("}\n");
-        fun.push_str("\n");
+        fun.push('\n');
 
-        fun.push_str(&format!("impl {name} {{\n", name = name(&table_item)));
+        fun.push_str(&format!("impl {name} {{\n", name = name(table_item)));
         fun.push_str(
             "    pub fn get_owner<'a>(&self, drawing: &'a Drawing) -> Option<DrawingItem<'a>> {\n",
         );
@@ -139,7 +133,7 @@ fn generate_table_items(fun: &mut String, element: &Element) {
         fun.push_str("        self.__owner_handle = drawing.assign_and_get_handle(item);\n");
         fun.push_str("    }\n");
         fun.push_str("}\n");
-        fun.push_str("\n");
+        fun.push('\n');
     }
 }
 
@@ -150,20 +144,20 @@ fn generate_table_reader(fun: &mut String, element: &Element) {
     fun.push_str("            if pair.code != 2 {\n");
     fun.push_str("                return Err(DxfError::ExpectedTableType(pair.offset));\n");
     fun.push_str("            }\n");
-    fun.push_str("\n");
+    fun.push('\n');
     fun.push_str("            match &*pair.assert_string()? {\n");
 
-    for table in &element.children {
+    for table in child_elements(element) {
         fun.push_str(&format!(
             "                \"{table_name}\" => read_{collection}(drawing, iter)?,\n",
-            table_name = attr(&table, "TypeString"),
-            collection = attr(&table, "Collection")
+            table_name = attr(table, "TypeString"),
+            collection = attr(table, "Collection")
         ));
     }
 
     fun.push_str("                _ => Drawing::swallow_table(iter)?,\n");
     fun.push_str("            }\n");
-    fun.push_str("\n");
+    fun.push('\n');
     fun.push_str("            match iter.next() {\n");
     fun.push_str("                Some(Ok(CodePair { code: 0, value: CodePairValue::Str(ref s), .. })) if s == \"ENDTAB\" => (),\n");
     fun.push_str("                Some(Ok(pair)) => return Err(DxfError::UnexpectedCodePair(pair, String::from(\"expected 0/ENDTAB\"))),\n");
@@ -174,32 +168,32 @@ fn generate_table_reader(fun: &mut String, element: &Element) {
     fun.push_str("        Some(Err(e)) => return Err(e),\n");
     fun.push_str("        None => return Err(DxfError::UnexpectedEndOfInput),\n");
     fun.push_str("    }\n");
-    fun.push_str("\n");
+    fun.push('\n');
     fun.push_str("    Ok(())\n");
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
-    for table in &element.children {
-        let table_item = &table.children[0];
-        let collection = attr(&table, "Collection");
+    for table in child_elements(element) {
+        let table_item = first_child_element(table);
+        let collection = attr(table, "Collection");
         let (item_type, _) = collection.split_at(collection.len() - 1); // remove the 's' suffix
 
-        fun.push_str(&format!("fn read_{collection}(drawing: &mut Drawing, iter: &mut CodePairPutBack) -> DxfResult<()> {{\n", collection=attr(&table, "Collection")));
+        fun.push_str(&format!("fn read_{collection}(drawing: &mut Drawing, iter: &mut CodePairPutBack) -> DxfResult<()> {{\n", collection=attr(table, "Collection")));
         fun.push_str("    loop {\n");
         fun.push_str("        match iter.next() {\n");
         fun.push_str("            Some(Ok(pair)) => {\n");
         fun.push_str("                if pair.code == 0 {\n");
         fun.push_str(&format!(
             "                    if pair.assert_string()? != \"{table_type}\" {{\n",
-            table_type = attr(&table, "TypeString")
+            table_type = attr(table, "TypeString")
         ));
         fun.push_str("                        iter.put_back(Ok(pair));\n");
         fun.push_str("                        break;\n");
         fun.push_str("                    }\n");
-        fun.push_str("\n");
+        fun.push('\n');
         fun.push_str(&format!(
             "                    let mut item = {typ}::default();\n",
-            typ = attr(&table_item, "Name")
+            typ = attr(table_item, "Name")
         ));
         fun.push_str("                    loop {\n");
         fun.push_str("                        match iter.next() {\n");
@@ -230,22 +224,22 @@ fn generate_table_reader(fun: &mut String, element: &Element) {
         fun.push_str(
             "                                    330 => item.__owner_handle = pair.as_handle()?,\n",
         );
-        for field in &table_item.children {
-            if generate_reader(&field) {
-                for (i, &cd) in codes(&field).iter().enumerate() {
-                    let reader = get_field_reader(&field);
-                    let codes = codes(&field);
+        for field in child_elements(table_item) {
+            if generate_reader(field) {
+                for (i, &cd) in codes(field).iter().enumerate() {
+                    let reader = get_field_reader(field);
+                    let codes = codes(field);
                     let write_cmd = match codes.len() {
                         1 => {
-                            let read_fun = if allow_multiples(&field) {
+                            let read_fun = if allow_multiples(field) {
                                 format!(".push({})", reader)
                             } else {
                                 format!(" = {}", reader)
                             };
                             let normalized_field_name = if field.name == "Pointer" {
-                                format!("__{}_handle", name(&field))
+                                format!("__{}_handle", name(field))
                             } else {
-                                name(&field)
+                                name(field)
                             };
                             format!(
                                 "item.{field}{read_fun}",
@@ -262,7 +256,7 @@ fn generate_table_reader(fun: &mut String, element: &Element) {
                             };
                             format!(
                                 "item.{field}.{suffix} = {reader}",
-                                field = name(&field),
+                                field = name(field),
                                 suffix = suffix,
                                 reader = reader
                             )
@@ -286,7 +280,7 @@ fn generate_table_reader(fun: &mut String, element: &Element) {
         );
         fun.push_str("                        }\n");
         fun.push_str("                    }\n");
-        fun.push_str("\n");
+        fun.push('\n');
         fun.push_str("                    if item.handle.is_empty() {\n");
         fun.push_str(&format!(
             "                        drawing.add_{item_type}(item);\n",
@@ -308,10 +302,10 @@ fn generate_table_reader(fun: &mut String, element: &Element) {
         fun.push_str("            None => return Err(DxfError::UnexpectedEndOfInput),\n");
         fun.push_str("        }\n");
         fun.push_str("    }\n");
-        fun.push_str("\n");
+        fun.push('\n');
         fun.push_str("    Ok(())\n");
         fun.push_str("}\n");
-        fun.push_str("\n");
+        fun.push('\n');
     }
 }
 
@@ -319,17 +313,17 @@ fn generate_table_writer(fun: &mut String, element: &Element) {
     fun.push_str(
         "pub(crate) fn add_table_code_pairs(drawing: &Drawing, pairs: &mut Vec<CodePair>, write_handles: bool) {\n",
     );
-    for table in &element.children {
+    for table in child_elements(element) {
         let mut indention = "";
         let mut predicates = vec![];
-        if !min_version(&table).is_empty() {
+        if !min_version(table).is_empty() {
             indention = "    ";
             predicates.push(format!(
                 "drawing.header.version >= AcadVersion::{}",
-                min_version(&table)
+                min_version(table)
             ));
         }
-        if predicates.len() != 0 {
+        if !predicates.is_empty() {
             fun.push_str(&format!(
                 "    if {predicate} {{\n",
                 predicate = predicates.join(" && ")
@@ -337,110 +331,110 @@ fn generate_table_writer(fun: &mut String, element: &Element) {
         }
         fun.push_str(&format!(
             "    {indention}add_{collection}_code_pairs(pairs, drawing, write_handles);\n",
-            collection = attr(&table, "Collection"),
+            collection = attr(table, "Collection"),
             indention = indention
         ));
-        if predicates.len() != 0 {
+        if !predicates.is_empty() {
             fun.push_str("    }\n");
         }
     }
 
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 
-    for table in &element.children {
-        let table_item = &table.children[0];
+    for table in child_elements(element) {
+        let table_item = first_child_element(table);
         fun.push_str("#[allow(clippy::cognitive_complexity)] // long function, no good way to simplify this\n");
-        fun.push_str(&format!("fn add_{collection}_code_pairs(pairs: &mut Vec<CodePair>, drawing: &Drawing, write_handles: bool) {{\n", collection=attr(&table, "Collection")));
+        fun.push_str(&format!("fn add_{collection}_code_pairs(pairs: &mut Vec<CodePair>, drawing: &Drawing, write_handles: bool) {{\n", collection=attr(table, "Collection")));
         fun.push_str(&format!(
             "    if !drawing.{collection}().any(|_| true) {{ // is empty\n",
-            collection = attr(&table, "Collection")
+            collection = attr(table, "Collection")
         ));
         fun.push_str("        return; // nothing to add\n");
         fun.push_str("    }\n");
-        fun.push_str("\n");
+        fun.push('\n');
         fun.push_str("    pairs.push(CodePair::new_str(0, \"TABLE\"));\n");
         fun.push_str(&format!(
             "    pairs.push(CodePair::new_str(2, \"{type_string}\"));\n",
-            type_string = attr(&table, "TypeString")
+            type_string = attr(table, "TypeString")
         ));
 
         // TODO: assign and write table handles
         // fun.push_str("    if write_handles {\n");
         // fun.push_str("        pairs.push(CodePair::new_str(5, \"0\"));\n");
         // fun.push_str("    }\n");
-        // fun.push_str("\n");
+        // fun.push('\n');
 
-        let item_type = name(&table_item);
+        let item_type = name(table_item);
 
         fun.push_str("    pairs.push(CodePair::new_str(100, \"AcDbSymbolTable\"));\n");
         fun.push_str("    pairs.push(CodePair::new_i16(70, 0));\n");
         fun.push_str(&format!(
             "    for item in drawing.{collection}() {{\n",
-            collection = attr(&table, "Collection")
+            collection = attr(table, "Collection")
         ));
         fun.push_str(&format!(
             "        pairs.push(CodePair::new_str(0, \"{type_string}\"));\n",
-            type_string = attr(&table, "TypeString")
+            type_string = attr(table, "TypeString")
         ));
         fun.push_str("        if write_handles {\n");
-        fun.push_str(&format!("            pairs.push(CodePair::new_string(5, &DrawingItem::{item_type}(&item).get_handle().as_string()));\n",
+        fun.push_str(&format!("            pairs.push(CodePair::new_string(5, &DrawingItem::{item_type}(item).get_handle().as_string()));\n",
             item_type=item_type));
         fun.push_str("        }\n");
-        fun.push_str("\n");
+        fun.push('\n');
         fun.push_str("        if drawing.header.version >= AcadVersion::R14 {\n");
         fun.push_str("            for group in &item.extension_data_groups {\n");
         fun.push_str("                group.add_code_pairs(pairs);\n");
         fun.push_str("            }\n");
         fun.push_str("        }\n");
-        fun.push_str("\n");
+        fun.push('\n');
         fun.push_str("        pairs.push(CodePair::new_str(100, \"AcDbSymbolTableRecord\"));\n");
         fun.push_str(&format!(
             "        pairs.push(CodePair::new_str(100, \"{class_name}\"));\n",
-            class_name = attr(&table_item, "ClassName")
+            class_name = attr(table_item, "ClassName")
         ));
         fun.push_str("        pairs.push(CodePair::new_string(2, &item.name));\n");
         fun.push_str("        pairs.push(CodePair::new_i16(70, 0));\n"); // TODO: flags
-        for field in &table_item.children {
-            if generate_writer(&field) {
+        for field in child_elements(table_item) {
+            if generate_writer(field) {
                 let mut predicates = vec![];
-                if !min_version(&field).is_empty() {
+                if !min_version(field).is_empty() {
                     predicates.push(format!(
                         "drawing.header.version >= AcadVersion::{}",
-                        min_version(&field)
+                        min_version(field)
                     ));
                 }
-                if !max_version(&field).is_empty() {
+                if !max_version(field).is_empty() {
                     predicates.push(format!(
                         "drawing.header.version <= AcadVersion::{}",
-                        max_version(&field)
+                        max_version(field)
                     ));
                 }
-                if !write_condition(&field).is_empty() {
-                    predicates.push(write_condition(&field));
+                if !write_condition(field).is_empty() {
+                    predicates.push(write_condition(field));
                 }
-                if disable_writing_default(&field) {
+                if disable_writing_default(field) {
                     predicates.push(format!(
                         "item.{field} != {default_value}",
-                        field = name(&field),
-                        default_value = default_value(&field)
+                        field = name(field),
+                        default_value = default_value(field)
                     ));
                 }
-                let indent = if predicates.len() == 0 { "" } else { "    " };
-                if predicates.len() != 0 {
+                let indent = if predicates.is_empty() { "" } else { "    " };
+                if !predicates.is_empty() {
                     fun.push_str(&format!(
                         "        if {predicate} {{\n",
                         predicate = predicates.join(" && ")
                     ));
                 }
 
-                if allow_multiples(&field) {
-                    let code = code(&field);
+                if allow_multiples(field) {
+                    let code = code(field);
                     if field.name == "Pointer" {
                         fun.push_str(&format!(
                             "{indent}        for x in &item.__{field}_handle {{\n",
                             indent = indent,
-                            field = name(&field)
+                            field = name(field)
                         ));
                         fun.push_str(&format!("{indent}            pairs.push(CodePair::new_string({code}, &x.as_string()));\n",
                             indent=indent, code=code));
@@ -455,7 +449,7 @@ fn generate_table_writer(fun: &mut String, element: &Element) {
                         fun.push_str(&format!(
                             "{indent}        for x in &item.{field} {{\n",
                             indent = indent,
-                            field = name(&field)
+                            field = name(field)
                         ));
                         fun.push_str(&format!(
                             "{indent}            pairs.push(CodePair::new_{typ}({code}, {val}));\n",
@@ -467,20 +461,20 @@ fn generate_table_writer(fun: &mut String, element: &Element) {
                     }
                     fun.push_str(&format!("{indent}        }}\n", indent = indent));
                 } else {
-                    let codes = codes(&field);
+                    let codes = codes(field);
                     if codes.len() == 1 {
                         let code = codes[0];
                         if field.name == "Pointer" {
                             fun.push_str(&format!("{indent}        pairs.push(CodePair::new_string({code}, &item.__{field}_handle.as_string()));\n",
-                                indent=indent, code=code, field=name(&field)));
+                                indent=indent, code=code, field=name(field)));
                         } else {
                             let typ = ExpectedType::get_expected_type(code).unwrap();
                             let typ = get_code_pair_type(&typ);
-                            let value = format!("item.{}", name(&field));
-                            let write_converter = if attr(&field, "WriteConverter").is_empty() {
+                            let value = format!("item.{}", name(field));
+                            let write_converter = if attr(field, "WriteConverter").is_empty() {
                                 String::from("{}")
                             } else {
-                                attr(&field, "WriteConverter")
+                                attr(field, "WriteConverter")
                             };
                             let value = write_converter.replace("{}", &value);
                             fun.push_str(&format!("{indent}        pairs.push(CodePair::new_{typ}({code}, {value}));\n",
@@ -495,12 +489,12 @@ fn generate_table_writer(fun: &mut String, element: &Element) {
                                 _ => panic!("impossible"),
                             };
                             fun.push_str(&format!("{indent}        pairs.push(CodePair::new_f64({code}, item.{field}.{suffix}));\n",
-                                indent=indent, code=code, field=name(&field), suffix=suffix));
+                                indent=indent, code=code, field=name(field), suffix=suffix));
                         }
                     }
                 }
 
-                if predicates.len() != 0 {
+                if !predicates.is_empty() {
                     fun.push_str("        }\n");
                 }
             }
@@ -511,10 +505,10 @@ fn generate_table_writer(fun: &mut String, element: &Element) {
         fun.push_str("        }\n");
 
         fun.push_str("    }\n");
-        fun.push_str("\n");
+        fun.push('\n');
         fun.push_str("    pairs.push(CodePair::new_str(0, \"ENDTAB\"));\n");
         fun.push_str("}\n");
-        fun.push_str("\n");
+        fun.push('\n');
     }
 }
 

--- a/build/test_helper_generator.rs
+++ b/build/test_helper_generator.rs
@@ -1,12 +1,11 @@
-extern crate xmltree;
-use self::xmltree::Element;
-
 use crate::xml_helpers::*;
-
-use std::fs::File;
-use std::io::{BufReader, Write};
-use std::iter::Iterator;
-use std::path::Path;
+use std::{
+    fs::File,
+    io::{BufReader, Write},
+    iter::Iterator,
+    path::Path,
+};
+use xmltree::Element;
 
 pub fn generate_test_helpers(generated_dir: &Path) {
     let _ = ::std::fs::create_dir(generated_dir.join("tests")); // might fail if it's already there
@@ -28,7 +27,7 @@ use crate::enums::*;
 use crate::entities::*;
 use crate::objects::*;
 ".trim_start());
-    fun.push_str("\n");
+    fun.push('\n');
     let mut file = File::create(generated_dir.join("tests/all_types.rs"))
         .ok()
         .unwrap();
@@ -46,11 +45,11 @@ fn generate_entity_helpers(fun: &mut String) {
     fun.push_str("#[allow(dead_code)]\n");
     fun.push_str("pub fn get_all_entity_types() -> Vec<(&'static str, &'static str, EntityType, AcadVersion)> {\n");
     fun.push_str("    vec![\n");
-    for c in &element.children {
+    for c in child_elements(&element) {
         if name(c) != "Entity" && name(c) != "DimensionBase" {
-            let type_string = attr(&c, "TypeString");
+            let type_string = attr(c, "TypeString");
             let type_strings = type_string.split(',').collect::<Vec<_>>();
-            let subclass = attr(&c, "SubclassMarker");
+            let subclass = attr(c, "SubclassMarker");
             let maxver = max_version(c);
             let maxver = if maxver.is_empty() {
                 String::from("R2018")
@@ -68,7 +67,7 @@ fn generate_entity_helpers(fun: &mut String) {
     }
     fun.push_str("    ]\n");
     fun.push_str("}\n");
-    fun.push_str("\n");
+    fun.push('\n');
 }
 
 fn generate_object_helpers(fun: &mut String) {
@@ -82,9 +81,9 @@ fn generate_object_helpers(fun: &mut String) {
         "pub fn get_all_object_types() -> Vec<(&'static str, ObjectType, AcadVersion)> {\n",
     );
     fun.push_str("    vec![\n");
-    for c in &element.children {
+    for c in child_elements(&element) {
         if name(c) != "Object" {
-            let type_string = attr(&c, "TypeString");
+            let type_string = attr(c, "TypeString");
             let type_strings = type_string.split(',').collect::<Vec<_>>();
             let maxver = max_version(c);
             let maxver = if maxver.is_empty() {

--- a/build/xml_helpers.rs
+++ b/build/xml_helpers.rs
@@ -1,13 +1,8 @@
-extern crate xmltree;
-use self::xmltree::Element;
-use crate::other_helpers::*;
-use crate::ExpectedType;
+use crate::{other_helpers::*, ExpectedType};
+use xmltree::{Element, XMLNode};
 
 pub fn attr(element: &Element, name: &str) -> String {
-    match &element.attributes.get(name) {
-        &Some(v) => v.clone(),
-        &None => String::new(),
-    }
+    element.attributes.get(name).cloned().unwrap_or_default()
 }
 
 pub fn allow_multiples(element: &Element) -> bool {
@@ -23,41 +18,41 @@ pub fn code(element: &Element) -> i32 {
 }
 
 pub fn codes(element: &Element) -> Vec<i32> {
-    let code_overrides = attr(&element, "CodeOverrides");
+    let code_overrides = attr(element, "CodeOverrides");
     if code_overrides.is_empty() {
-        return vec![code(&element)];
+        vec![code(element)]
     } else {
-        return code_overrides
-            .split(",")
+        code_overrides
+            .split(',')
             .map(|c| c.parse::<i32>().unwrap())
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
     }
 }
 
 pub fn default_value(element: &Element) -> String {
-    attr(&element, "DefaultValue")
+    attr(element, "DefaultValue")
 }
 
 pub fn disable_writing_default(element: &Element) -> bool {
-    attr(&element, "DisableWritingDefault") == "true"
+    attr(element, "DisableWritingDefault") == "true"
 }
 
 pub fn generate_reader(element: &Element) -> bool {
-    attr(&element, "GenerateReader") != "false"
+    attr(element, "GenerateReader") != "false"
 }
 
 pub fn generate_writer(element: &Element) -> bool {
-    attr(&element, "GenerateWriter") != "false"
+    attr(element, "GenerateWriter") != "false"
 }
 
 pub fn get_field_reader(element: &Element) -> String {
-    let reader_override = attr(&element, "ReaderOverride");
+    let reader_override = attr(element, "ReaderOverride");
     if !reader_override.is_empty() {
         reader_override
     } else {
-        let expected_type = ExpectedType::get_expected_type(code(&element)).unwrap();
+        let expected_type = ExpectedType::get_expected_type(code(element)).unwrap();
         let reader_fun = get_reader_function(&expected_type);
-        let mut read_converter = attr(&element, "ReadConverter");
+        let mut read_converter = attr(element, "ReadConverter");
         if read_converter.is_empty() {
             read_converter = String::from("{}");
         }
@@ -73,10 +68,10 @@ pub fn get_field_reader(element: &Element) -> String {
 
 pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
     let mut fun = String::new();
-    let typ = attr(&pointer, "Type");
-    let sub_type = attr(&pointer, "SubType");
-    let normalized_field_name = format!("__{}_handle", name(&pointer));
-    let return_type = match (allow_multiples(&pointer), typ.is_empty()) {
+    let typ = attr(pointer, "Type");
+    let sub_type = attr(pointer, "SubType");
+    let normalized_field_name = format!("__{}_handle", name(pointer));
+    let return_type = match (allow_multiples(pointer), typ.is_empty()) {
         (true, true) => String::from("Vec<DrawingItem<'a>>"),
         (true, false) => format!("Vec<&'a {}>", typ),
         (false, true) => String::from("Option<DrawingItem<'a>>"),
@@ -86,49 +81,45 @@ pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
     // get method
     fun.push_str(&format!(
         "    pub fn get_{name}<'a>(&self, drawing: &'a Drawing) -> {return_type} {{\n",
-        name = name(&pointer),
+        name = name(pointer),
         return_type = return_type
     ));
     if !typ.is_empty() {
-        if allow_multiples(&pointer) {
+        if allow_multiples(pointer) {
             if !sub_type.is_empty() {
                 fun.push_str(&format!(
                     "        self.{field}.iter().filter_map(|&h| {{\n",
                     field = normalized_field_name
                 ));
-                fun.push_str(&format!(
-                    "            match drawing.get_item_by_handle(h) {{\n"
-                ));
+                fun.push_str("            match drawing.get_item_by_handle(h) {\n");
                 fun.push_str(&format!(
                     "                Some(DrawingItem::{typ}(val)) => {{\n",
                     typ = typ
                 ));
-                fun.push_str(&format!("                    match val.specific {{\n"));
+                fun.push_str("                    match val.specific {\n");
                 fun.push_str(&format!(
                     "                        {typ}Type::{sub_type}(_) => Some(val),\n",
                     typ = typ,
                     sub_type = sub_type
                 ));
-                fun.push_str(&format!("                        _ => None,\n"));
-                fun.push_str(&format!("                    }}\n"));
-                fun.push_str(&format!("                }},\n"));
-                fun.push_str(&format!("                _ => None,\n"));
-                fun.push_str(&format!("            }}\n"));
+                fun.push_str("                        _ => None,\n");
+                fun.push_str("                    }\n");
+                fun.push_str("                },\n");
+                fun.push_str("                _ => None,\n");
+                fun.push_str("            }\n");
                 fun.push_str("        }).collect()\n");
             } else {
                 fun.push_str(&format!(
                     "        self.{field}.iter().filter_map(|&h| {{\n",
                     field = normalized_field_name
                 ));
-                fun.push_str(&format!(
-                    "            match drawing.get_item_by_handle(h) {{\n"
-                ));
+                fun.push_str("            match drawing.get_item_by_handle(h) {\n");
                 fun.push_str(&format!(
                     "                Some(DrawingItem::{typ}(val)) => Some(val),\n",
                     typ = typ
                 ));
-                fun.push_str(&format!("                _ => None,\n"));
-                fun.push_str(&format!("            }}\n"));
+                fun.push_str("                _ => None,\n");
+                fun.push_str("            }\n");
                 fun.push_str("        }).collect()\n");
             }
         } else {
@@ -159,27 +150,25 @@ pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
             fun.push_str("            _ => None,\n");
             fun.push_str("        }\n");
         }
+    } else if allow_multiples(pointer) {
+        fun.push_str(&format!("        self.{field}.iter().filter_map(|&h| drawing.get_item_by_handle(h)).collect()\n", field=normalized_field_name));
     } else {
-        if allow_multiples(&pointer) {
-            fun.push_str(&format!("        self.{field}.iter().filter_map(|&h| drawing.get_item_by_handle(h)).collect()\n", field=normalized_field_name));
-        } else {
-            fun.push_str(&format!(
-                "        drawing.get_item_by_handle(self.{field})\n",
-                field = normalized_field_name
-            ));
-        }
+        fun.push_str(&format!(
+            "        drawing.get_item_by_handle(self.{field})\n",
+            field = normalized_field_name
+        ));
     }
 
     fun.push_str("    }\n");
 
     // add/set method
-    if allow_multiples(&pointer) {
+    if allow_multiples(pointer) {
         match (typ.is_empty(), sub_type.is_empty()) {
             (false, false) => {
                 // we know the very specific type and should fail if it's not correct
                 fun.push_str(&format!(
                     "    pub fn add_{name}(&mut self, item: &{typ}) -> DxfResult<()> {{\n",
-                    name = name(&pointer),
+                    name = name(pointer),
                     typ = typ
                 ));
                 fun.push_str("        match item.specific {\n");
@@ -187,14 +176,14 @@ pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
                     typ=typ, sub_type=sub_type, field=normalized_field_name));
                 fun.push_str("            _ => return Err(DxfError::WrongItemType),\n");
                 fun.push_str("        }\n");
-                fun.push_str("\n");
+                fun.push('\n');
                 fun.push_str("        Ok(())\n");
             }
             (false, true) => {
                 // we know the high level type
                 fun.push_str(&format!(
                     "    pub fn add_{name}(&mut self, item: &{typ}) {{\n",
-                    name = name(&pointer),
+                    name = name(pointer),
                     typ = typ
                 ));
                 fun.push_str(&format!(
@@ -207,7 +196,7 @@ pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
                 // we don't know what type this should be
                 fun.push_str(&format!(
                     "    pub fn add_{name}(&mut self, item: &DrawingItemMut) {{\n",
-                    name = name(&pointer)
+                    name = name(pointer)
                 ));
                 fun.push_str(&format!(
                     "        self.{field}.push(item.get_handle());\n",
@@ -222,7 +211,7 @@ pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
                 // we know the very specific type and should fail if it's not correct
                 fun.push_str(&format!(
                     "    pub fn set_{name}(&mut self, item: &{typ}) -> DxfResult<()> {{\n",
-                    name = name(&pointer),
+                    name = name(pointer),
                     typ = typ
                 ));
                 fun.push_str("        match item.specific {\n");
@@ -230,14 +219,14 @@ pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
                     typ=typ, sub_type=sub_type, field=normalized_field_name));
                 fun.push_str("            _ => return Err(DxfError::WrongItemType),\n");
                 fun.push_str("        }\n");
-                fun.push_str("\n");
+                fun.push('\n');
                 fun.push_str("        Ok(())\n");
             }
             (false, true) => {
                 // we know the high level type
                 fun.push_str(&format!(
                     "    pub fn set_{name}(&mut self, item: &{typ}) {{\n",
-                    name = name(&pointer),
+                    name = name(pointer),
                     typ = typ
                 ));
                 fun.push_str(&format!(
@@ -250,7 +239,7 @@ pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
                 // we don't know what type this should be
                 fun.push_str(&format!(
                     "    pub fn set_{name}(&mut self, item: &DrawingItemMut) {{\n",
-                    name = name(&pointer)
+                    name = name(pointer)
                 ));
                 fun.push_str(&format!(
                     "        self.{field} = item.get_handle();\n",
@@ -266,11 +255,11 @@ pub fn get_methods_for_pointer_access(pointer: &Element) -> String {
 }
 
 pub fn min_version(element: &Element) -> String {
-    attr(&element, "MinVersion")
+    attr(element, "MinVersion")
 }
 
 pub fn max_version(element: &Element) -> String {
-    attr(&element, "MaxVersion")
+    attr(element, "MaxVersion")
 }
 
 pub fn name(element: &Element) -> String {
@@ -287,4 +276,18 @@ pub fn typ(element: &Element) -> String {
 
 pub fn write_condition(element: &Element) -> String {
     attr(element, "WriteCondition")
+}
+
+pub fn child_elements(node: &Element) -> impl Iterator<Item = &Element> + '_ {
+    node.children.iter().filter_map(|c| {
+        if let XMLNode::Element(e) = c {
+            Some(e)
+        } else {
+            None
+        }
+    })
+}
+
+pub fn first_child_element(node: &Element) -> &Element {
+    child_elements(node).next().unwrap()
 }

--- a/dxf2json/Cargo.toml
+++ b/dxf2json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dxf2json"
 version = "0.1.0"
 authors = ["Brett V. Forsgren <brett.forsgren@outlook.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 dxf = { path = "../", features = ["serialize"] }

--- a/dxf2json/src/main.rs
+++ b/dxf2json/src/main.rs
@@ -1,7 +1,3 @@
-extern crate dxf;
-extern crate serde;
-extern crate serde_json;
-
 use dxf::Drawing;
 use std::env;
 use std::fs::File;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dxf-examples"
 version = "0.1.0"
 authors = ["Brett V. Forsgren <brett.forsgren@outlook.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 dxf = { path = "../" }

--- a/examples/src/block_examples.rs
+++ b/examples/src/block_examples.rs
@@ -1,6 +1,4 @@
-use dxf::entities::*;
-use dxf::enums::AcadVersion;
-use dxf::{Block, Drawing, Point};
+use dxf::{entities::*, enums::AcadVersion, Block, Drawing, Point};
 
 pub fn all() -> dxf::DxfResult<()> {
     basic_block_and_insert()?;
@@ -14,8 +12,10 @@ fn basic_block_and_insert() -> dxf::DxfResult<()> {
     //
     // create a block with a unique name...
     //
-    let mut block = Block::default();
-    block.name = "my-block-name".to_string();
+    let mut block = Block {
+        name: "my-block-name".to_string(),
+        ..Default::default()
+    };
 
     //
     // ...and populate it with entities
@@ -37,9 +37,11 @@ fn basic_block_and_insert() -> dxf::DxfResult<()> {
     //
     // add a reference to the block with an `INSERT` entity
     //
-    let mut insert = Insert::default();
-    insert.name = "my-block-name".to_string(); // use the same name as the block defined above
-    insert.location = Point::new(3.0, 3.0, 0.0); // select the base-point of the insertion
+    let insert = Insert {
+        name: "my-block-name".to_string(), // use the same name as the block defined above
+        location: Point::new(3.0, 3.0, 0.0), // select the base-point of the insertion
+        ..Default::default()
+    };
     drawing.add_entity(Entity {
         common: Default::default(),
         specific: EntityType::Insert(insert),

--- a/examples/src/line_type_examples.rs
+++ b/examples/src/line_type_examples.rs
@@ -1,5 +1,4 @@
-use dxf::entities::*;
-use dxf::{Drawing, Point};
+use dxf::{entities::*, Drawing, Point};
 
 pub fn all() -> dxf::DxfResult<()> {
     apply_line_types_to_entities()?;
@@ -12,12 +11,14 @@ fn apply_line_types_to_entities() -> dxf::DxfResult<()> {
     //
     // create a new line type named "dashed-lines"...
     //
-    let mut line_type = dxf::tables::LineType::default();
-    line_type.name = String::from("dashed-lines");
-    line_type.total_pattern_length = 1.0;
-    // line pattern contains 2 elements; positive values draw a line, negative values draw a gap
-    // the following draws 3/4 of a line with a 1/4 gap
-    line_type.element_count = 2;
+    let mut line_type = dxf::tables::LineType {
+        name: String::from("dashed-lines"),
+        total_pattern_length: 1.0,
+        // line pattern contains 2 elements; positive values draw a line, negative values draw a gap
+        // the following draws 3/4 of a line with a 1/4 gap
+        element_count: 2,
+        ..Default::default()
+    };
     line_type.dash_dot_space_lengths.push(0.75);
     line_type.dash_dot_space_lengths.push(-0.25);
     drawing.add_line_type(line_type);

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,5 +1,3 @@
-extern crate dxf;
-
 mod block_examples;
 mod line_type_examples;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,15 +1,8 @@
 use crate::{
-    CodePair, CodePairValue, Drawing, DrawingItem, DrawingItemMut, DxfError, DxfResult,
-    ExtensionGroup, Handle, Point, XData,
+    code_pair_put_back::CodePairPutBack, entities::Entity, entity_iter::EntityIter, enums::*,
+    extension_data, helper_functions::*, x_data, CodePair, CodePairValue, Drawing, DrawingItem,
+    DrawingItemMut, DxfError, DxfResult, ExtensionGroup, Handle, Point, XData,
 };
-
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::entities::Entity;
-use crate::entity_iter::EntityIter;
-use crate::enums::*;
-use crate::extension_data;
-use crate::helper_functions::*;
-use crate::x_data;
 
 /// A block is a collection of entities.
 #[derive(Debug, Clone)]
@@ -301,10 +294,7 @@ impl Block {
 
 #[cfg(test)]
 mod tests {
-    use crate::entities::*;
-    use crate::enums::*;
-    use crate::helper_functions::tests::*;
-    use crate::*;
+    use crate::{entities::*, enums::*, helper_functions::tests::*, *};
 
     fn read_blocks_section(content: Vec<CodePair>) -> Drawing {
         let mut pairs = vec![
@@ -711,8 +701,10 @@ mod tests {
     fn write_block_r12_compat() {
         let mut drawing = Drawing::new();
         drawing.header.version = AcadVersion::R12;
-        let mut block = Block::default();
-        block.name = "block-name".to_string();
+        let mut block = Block {
+            name: "block-name".to_string(),
+            ..Default::default()
+        };
         block.entities.push(Entity {
             common: Default::default(),
             specific: EntityType::Line(Line::new(

--- a/src/class.rs
+++ b/src/class.rs
@@ -1,8 +1,7 @@
-use crate::{CodePair, Drawing, DxfError, DxfResult};
-
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::enums::*;
-use crate::helper_functions::*;
+use crate::{
+    code_pair_put_back::CodePairPutBack, enums::*, helper_functions::*, CodePair, Drawing,
+    DxfError, DxfResult,
+};
 
 /// Represents an application-defined class whose instances are `Block`s, `Entity`s, and `Object`s.
 #[derive(Clone)]
@@ -231,9 +230,7 @@ impl Class {
 
 #[cfg(test)]
 mod tests {
-    use crate::enums::*;
-    use crate::helper_functions::tests::*;
-    use crate::*;
+    use crate::{enums::*, helper_functions::tests::*, *};
 
     fn read_single_class(version_str: &str, body: Vec<CodePair>) -> Class {
         let mut pairs = vec![

--- a/src/code_pair.rs
+++ b/src/code_pair.rs
@@ -1,13 +1,9 @@
-extern crate byteorder;
-
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
-
-use self::byteorder::{BigEndian, ByteOrder};
-
-use crate::{CodePairValue, DxfError, DxfResult, Handle};
-
-use crate::helper_functions::parse_hex_string;
+use crate::{helper_functions::parse_hex_string, CodePairValue, DxfError, DxfResult, Handle};
+use byteorder::{BigEndian, ByteOrder};
+use std::{
+    fmt,
+    fmt::{Debug, Display, Formatter},
+};
 
 /// The basic primitive of a DXF file; a code indicating the type of the data contained, and the
 /// data itself.
@@ -99,7 +95,7 @@ impl CodePair {
 impl CodePair {
     pub(crate) fn as_handle(&self) -> DxfResult<Handle> {
         let mut bytes = vec![];
-        parse_hex_string(&self.assert_string()?.trim(), &mut bytes, self.offset)?;
+        parse_hex_string(self.assert_string()?.trim(), &mut bytes, self.offset)?;
         while bytes.len() < 8 {
             bytes.insert(0, 0);
         }

--- a/src/code_pair_iter.rs
+++ b/src/code_pair_iter.rs
@@ -1,7 +1,7 @@
-use crate::{CodePair, CodePairValue, DxfError, DxfResult, ExpectedType};
-
-use crate::code_pair_value::un_escape_ascii_to_unicode;
-use crate::helper_functions::*;
+use crate::{
+    code_pair_value::un_escape_ascii_to_unicode, helper_functions::*, CodePair, CodePairValue,
+    DxfError, DxfResult, ExpectedType,
+};
 use encoding_rs::Encoding;
 use std::io::{Cursor, Read};
 
@@ -241,7 +241,7 @@ impl<T: Read> BinaryCodePairIter<T> {
             ),
             ExpectedType::Str => {
                 let mut value = try_from_dxf_result!(self.read_string_binary());
-                if !self.code_size_detection_complete && code == 0 && value == "" {
+                if !self.code_size_detection_complete && code == 0 && value.is_empty() {
                     // If this is the first pair being read and the code is 0, the only valid string value is "SECTION".
                     // If the read value is instead empty, that means the string reader found a single 0x00 byte which
                     // indicates that this is a post R13 binary file where codes are always read as 2 bytes.  The 0x00
@@ -326,8 +326,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::code_pair_iter::{BinaryCodePairIter, TextCodePairIter};
-    use crate::CodePair;
+    use crate::{
+        code_pair_iter::{BinaryCodePairIter, TextCodePairIter},
+        CodePair,
+    };
 
     use super::DirectCodePairIter;
 

--- a/src/code_pair_put_back.rs
+++ b/src/code_pair_put_back.rs
@@ -1,6 +1,4 @@
-use crate::code_pair_iter::CodePairIter;
-use crate::dxf_result::DxfResult;
-use crate::CodePair;
+use crate::{code_pair_iter::CodePairIter, dxf_result::DxfResult, CodePair};
 
 pub(crate) struct CodePairPutBack {
     top: Vec<DxfResult<CodePair>>,

--- a/src/code_pair_value.rs
+++ b/src/code_pair_value.rs
@@ -1,6 +1,8 @@
-use std::borrow::Cow;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
+use std::{
+    borrow::Cow,
+    fmt,
+    fmt::{Debug, Display, Formatter},
+};
 
 /// Contains the data portion of a `CodePair`.
 #[derive(PartialEq)]
@@ -214,13 +216,9 @@ pub(crate) fn un_escape_ascii_to_unicode(val: &str) -> String {
             seq.push(c);
             if i == sequence_start + 6 {
                 in_escape_sequence = false;
-                if seq.starts_with("\\U+") {
-                    let code_str = &seq[3..];
+                if let Some(code_str) = seq.strip_prefix("\\U+") {
                     let decoded = match u32::from_str_radix(code_str, 16) {
-                        Ok(code) => match std::char::from_u32(code) {
-                            Some(c) => c,
-                            None => '?',
-                        },
+                        Ok(code) => std::char::from_u32(code).unwrap_or('?'),
                         Err(_) => '?',
                     };
                     result.push(decoded);

--- a/src/code_pair_writer.rs
+++ b/src/code_pair_writer.rs
@@ -1,11 +1,10 @@
+use crate::{
+    code_pair_value::{escape_control_characters, escape_unicode_to_ascii},
+    enums::AcadVersion,
+    CodePair, CodePairValue, DxfResult,
+};
+use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::Write;
-
-extern crate byteorder;
-use self::byteorder::{LittleEndian, WriteBytesExt};
-
-use crate::code_pair_value::{escape_control_characters, escape_unicode_to_ascii};
-use crate::enums::AcadVersion;
-use crate::{CodePair, CodePairValue, DxfResult};
 
 pub(crate) struct CodePairWriter<'a, T>
 where
@@ -53,7 +52,7 @@ impl<'a, T: Write + ?Sized> CodePairWriter<'a, T> {
             .write_fmt(format_args!("{: >3}\r\n", pair.code))?;
         match pair.value {
             CodePairValue::Str(ref s) => {
-                let s = escape_control_characters(&s);
+                let s = escape_control_characters(s);
                 let s = if self.text_as_ascii {
                     escape_unicode_to_ascii(&s)
                 } else {
@@ -110,9 +109,7 @@ impl<'a, T: Write + ?Sized> CodePairWriter<'a, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::code_pair_writer::CodePairWriter;
-    use crate::enums::AcadVersion;
-    use crate::CodePair;
+    use crate::{code_pair_writer::CodePairWriter, enums::AcadVersion, CodePair};
     use std::io::{BufRead, BufReader, Cursor, Seek, SeekFrom};
 
     fn write_in_binary(pair: &CodePair) -> Vec<u8> {
@@ -124,7 +121,7 @@ mod tests {
             version: AcadVersion::R2004,
         };
         writer
-            .write_binary_code_pair(&pair)
+            .write_binary_code_pair(pair)
             .expect("expected write to succeed");
         buf.seek(SeekFrom::Start(0))
             .expect("expected seek to succeed");
@@ -140,7 +137,7 @@ mod tests {
             version: AcadVersion::R2004,
         };
         writer
-            .write_ascii_code_pair(&pair)
+            .write_ascii_code_pair(pair)
             .expect("expected write to succeed");
         buf.seek(SeekFrom::Start(0))
             .expect("expected seek to succeed");

--- a/src/drawing_item.rs
+++ b/src/drawing_item.rs
@@ -1,7 +1,4 @@
-use crate::entities::*;
-use crate::objects::*;
-use crate::tables::*;
-use crate::{Block, Handle};
+use crate::{entities::*, objects::*, tables::*, Block, Handle};
 
 #[derive(Debug)]
 pub enum DrawingItem<'a> {
@@ -22,18 +19,18 @@ pub enum DrawingItem<'a> {
 impl<'a> DrawingItem<'a> {
     pub fn get_handle(&self) -> Handle {
         match self {
-            DrawingItem::AppId(ref app_id) => app_id.handle,
-            DrawingItem::Block(ref b) => b.handle,
-            DrawingItem::BlockRecord(ref br) => br.handle,
-            DrawingItem::DimStyle(ref ds) => ds.handle,
+            DrawingItem::AppId(app_id) => app_id.handle,
+            DrawingItem::Block(b) => b.handle,
+            DrawingItem::BlockRecord(br) => br.handle,
+            DrawingItem::DimStyle(ds) => ds.handle,
             DrawingItem::Entity(&Entity { ref common, .. }) => common.handle,
-            DrawingItem::Layer(ref l) => l.handle,
-            DrawingItem::LineType(ref l) => l.handle,
+            DrawingItem::Layer(l) => l.handle,
+            DrawingItem::LineType(l) => l.handle,
             DrawingItem::Object(&Object { ref common, .. }) => common.handle,
-            DrawingItem::Style(ref s) => s.handle,
-            DrawingItem::Ucs(ref u) => u.handle,
-            DrawingItem::View(ref v) => v.handle,
-            DrawingItem::ViewPort(ref v) => v.handle,
+            DrawingItem::Style(s) => s.handle,
+            DrawingItem::Ucs(u) => u.handle,
+            DrawingItem::View(v) => v.handle,
+            DrawingItem::ViewPort(v) => v.handle,
         }
     }
 }

--- a/src/dxb_reader.rs
+++ b/src/dxb_reader.rs
@@ -1,13 +1,9 @@
-use std::io::Read;
-
-use crate::{Block, Color, Drawing, DxfError, DxfResult, Point};
-
-use crate::dxb_item_type::DxbItemType;
-use crate::entities::*;
-use crate::entity_iter::collect_entities;
-use crate::helper_functions::*;
-
+use crate::{
+    dxb_item_type::DxbItemType, entities::*, entity_iter::collect_entities, helper_functions::*,
+    Block, Color, Drawing, DxfError, DxfResult, Point,
+};
 use enum_primitive::FromPrimitive;
+use std::io::Read;
 
 pub(crate) struct DxbReader<T: Read> {
     reader: T,
@@ -161,9 +157,11 @@ impl<T: Read> DxbReader<T> {
         drawing.clear();
         match block_base {
             Some(location) => {
-                let mut block = Block::default();
-                block.base_point = location;
-                block.entities = gathered_entities;
+                let block = Block {
+                    base_point: location,
+                    entities: gathered_entities,
+                    ..Default::default()
+                };
                 drawing.add_block(block);
             }
             None => {

--- a/src/dxb_writer.rs
+++ b/src/dxb_writer.rs
@@ -1,14 +1,7 @@
-use std::io::Write;
-
-extern crate byteorder;
-use self::byteorder::{LittleEndian, WriteBytesExt};
-
-use crate::{Drawing, DxfResult};
-
-use crate::dxb_item_type::DxbItemType;
-use crate::entities::*;
-
+use crate::{dxb_item_type::DxbItemType, entities::*, Drawing, DxfResult};
+use byteorder::{LittleEndian, WriteBytesExt};
 use itertools::Itertools;
+use std::io::Write;
 
 pub(crate) struct DxbWriter<T: Write> {
     writer: T,
@@ -58,7 +51,7 @@ impl<T: Write> DxbWriter<T> {
                             self.write_w(last_color)?;
                         }
                     }
-                    self.write_entity(&entity)?;
+                    self.write_entity(entity)?;
                 }
             }
         }
@@ -69,41 +62,41 @@ impl<T: Write> DxbWriter<T> {
     }
     fn write_entities(&mut self, entities: &[Entity]) -> DxfResult<()> {
         for entity in entities.iter() {
-            self.write_entity(&entity)?;
+            self.write_entity(entity)?;
         }
         Ok(())
     }
     fn write_entity(&mut self, entity: &Entity) -> DxfResult<()> {
         match &entity.specific {
             EntityType::Arc(ref arc) => {
-                self.write_arc(&arc)?;
+                self.write_arc(arc)?;
             }
             EntityType::Circle(ref circle) => {
-                self.write_circle(&circle)?;
+                self.write_circle(circle)?;
             }
             EntityType::Face3D(ref face) => {
-                self.write_face(&face)?;
+                self.write_face(face)?;
             }
             EntityType::Line(ref line) => {
-                self.write_line(&line)?;
+                self.write_line(line)?;
             }
             EntityType::ModelPoint(ref point) => {
-                self.write_point(&point)?;
+                self.write_point(point)?;
             }
             EntityType::Polyline(ref poly) => {
-                self.write_polyline(&poly)?;
+                self.write_polyline(poly)?;
             }
             EntityType::Seqend(_) => {
                 self.write_seqend()?;
             }
             EntityType::Solid(ref solid) => {
-                self.write_solid(&solid)?;
+                self.write_solid(solid)?;
             }
             EntityType::Trace(ref trace) => {
-                self.write_trace(&trace)?;
+                self.write_trace(trace)?;
             }
             EntityType::Vertex(ref vertex) => {
-                self.write_vertex(&vertex)?;
+                self.write_vertex(vertex)?;
             }
             _ => (),
         }
@@ -161,7 +154,7 @@ impl<T: Write> DxbWriter<T> {
         self.write_item_type(DxbItemType::Polyline)?;
         self.write_w(if poly.get_is_closed() { 1 } else { 0 })?;
         for vertex in poly.vertices() {
-            self.write_vertex(&vertex)?;
+            self.write_vertex(vertex)?;
         }
         self.write_seqend()?;
         Ok(())

--- a/src/dxf_error.rs
+++ b/src/dxf_error.rs
@@ -1,9 +1,5 @@
-use std::error;
-use std::fmt;
-use std::io;
-use std::num;
-
 use crate::CodePair;
+use std::{error, fmt, io, num};
 
 #[derive(Debug)]
 pub enum DxfError {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,14 +1,10 @@
 // other implementation is in `generated/entities.rs`
 
+use crate::{
+    code_pair_put_back::CodePairPutBack, entities::*, enums::*, helper_functions::*, CodePair,
+    Color, Drawing, DxfError, DxfResult, Handle, Point, Vector,
+};
 use enum_primitive::FromPrimitive;
-
-use crate::{CodePair, Color, DxfError, DxfResult, Handle, Point, Vector};
-
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::entities::*;
-use crate::enums::*;
-use crate::helper_functions::*;
-use crate::Drawing;
 
 //------------------------------------------------------------------------------
 //                                                                           Arc
@@ -669,8 +665,8 @@ impl Entity {
         }
     }
     fn apply_code_pair(&mut self, pair: &CodePair, iter: &mut CodePairPutBack) -> DxfResult<()> {
-        if !self.specific.try_apply_code_pair(&pair)? {
-            self.common.apply_individual_pair(&pair, iter)?;
+        if !self.specific.try_apply_code_pair(pair)? {
+            self.common.apply_individual_pair(pair, iter)?;
         }
         Ok(())
     }
@@ -1564,7 +1560,7 @@ impl Entity {
                     };
                     a.add_code_pairs(pairs, version, write_handles);
                 }
-                if ins.__attributes_and_handles.len() > 0 {
+                if !ins.__attributes_and_handles.is_empty() {
                     Entity::add_code_pairs_seqend(pairs, version, write_handles);
                 }
             }
@@ -1618,11 +1614,7 @@ impl Entity {
 
 #[cfg(test)]
 mod tests {
-    use crate::entities::*;
-    use crate::enums::*;
-    use crate::helper_functions::tests::*;
-    use crate::objects::*;
-    use crate::*;
+    use crate::{entities::*, enums::*, helper_functions::tests::*, objects::*, *};
 
     fn read_entity(entity_type: &str, body: Vec<CodePair>) -> Entity {
         let mut pairs = vec![CodePair::new_str(0, entity_type)];
@@ -2623,8 +2615,10 @@ mod tests {
     fn write_lw_polyline() {
         let mut drawing = Drawing::new();
         drawing.header.version = AcadVersion::R2013;
-        let mut poly = LwPolyline::default();
-        poly.constant_width = 43.0;
+        let mut poly = LwPolyline {
+            constant_width: 43.0,
+            ..Default::default()
+        };
         poly.vertices.push(LwPolylineVertex {
             x: 1.1,
             y: 2.1,
@@ -2783,8 +2777,10 @@ mod tests {
     #[test]
     fn write_insert_no_embedded_attributes() {
         let mut drawing = Drawing::new();
-        let mut ins = Insert::default();
-        ins.name = "insert-name".to_string();
+        let ins = Insert {
+            name: "insert-name".to_string(),
+            ..Default::default()
+        };
         let ent = Entity::new(EntityType::Insert(ins));
         drawing.add_entity(ent);
         assert_not_contains_pairs(
@@ -2821,8 +2817,10 @@ mod tests {
     fn write_insert_no_extrusion_on_r12() {
         let mut drawing = Drawing::new();
         drawing.header.version = AcadVersion::R12;
-        let mut ins = Insert::default();
-        ins.extrusion_direction = Vector::new(1.0, 2.0, 3.0);
+        let ins = Insert {
+            extrusion_direction: Vector::new(1.0, 2.0, 3.0),
+            ..Default::default()
+        };
         let ent = Entity::new(EntityType::Insert(ins));
         drawing.add_entity(ent);
         assert_not_contains_pairs(
@@ -2839,8 +2837,10 @@ mod tests {
     fn write_insert_extrusion_on_r13() {
         let mut drawing = Drawing::new();
         drawing.header.version = AcadVersion::R13;
-        let mut ins = Insert::default();
-        ins.extrusion_direction = Vector::new(1.0, 2.0, 3.0);
+        let ins = Insert {
+            extrusion_direction: Vector::new(1.0, 2.0, 3.0),
+            ..Default::default()
+        };
         let ent = Entity::new(EntityType::Insert(ins));
         drawing.add_entity(ent);
         assert_contains_pairs(
@@ -3154,10 +3154,12 @@ mod tests {
     fn normalize_mline_styles() {
         let mut file = Drawing::new();
         file.clear();
-        let objects = file.objects().collect::<Vec<_>>();
-        assert_eq!(0, objects.len());
-        let mut mline = MLine::default();
-        mline.style_name = String::from("style name");
+        let objects = file.objects().count();
+        assert_eq!(0, objects);
+        let mline = MLine {
+            style_name: String::from("style name"),
+            ..Default::default()
+        };
         file.add_entity(Entity::new(EntityType::MLine(mline)));
         file.normalize();
         let objects = file.objects().collect::<Vec<_>>();

--- a/src/entity_iter.rs
+++ b/src/entity_iter.rs
@@ -1,8 +1,6 @@
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::drawing::AUTO_REPLACE_HANDLE;
-use crate::entities::*;
-use crate::DxfResult;
-
+use crate::{
+    code_pair_put_back::CodePairPutBack, drawing::AUTO_REPLACE_HANDLE, entities::*, DxfResult,
+};
 use itertools::{put_back, PutBack};
 
 pub(crate) struct EntityIter<'a> {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,3 @@
-extern crate num;
-
 use crate::{DxfError, DxfResult};
 use std::fmt;
 

--- a/src/extension_data.rs
+++ b/src/extension_data.rs
@@ -1,6 +1,4 @@
-use crate::{CodePair, DxfError, DxfResult};
-
-use crate::code_pair_put_back::CodePairPutBack;
+use crate::{code_pair_put_back::CodePairPutBack, CodePair, DxfError, DxfResult};
 
 pub(crate) const EXTENSION_DATA_GROUP: i32 = 102;
 

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -3,18 +3,22 @@
 
 //include!(concat!(env!("OUT_DIR"), "/generated/mod.rs"));
 
+#[allow(clippy::all)]
 pub mod entities {
     include!(concat!(env!("OUT_DIR"), "/generated/entities.rs"));
 }
 
+#[allow(clippy::all)]
 pub mod header {
     include!(concat!(env!("OUT_DIR"), "/generated/header.rs"));
 }
 
+#[allow(clippy::all)]
 pub mod objects {
     include!(concat!(env!("OUT_DIR"), "/generated/objects.rs"));
 }
 
+#[allow(clippy::all)]
 pub mod tables {
     include!(concat!(env!("OUT_DIR"), "/generated/tables.rs"));
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,9 +1,9 @@
 // other implementation is in `generated/header.rs`
 
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::enums::*;
-use crate::helper_functions::*;
-use crate::{CodePair, DxfError, DxfResult};
+use crate::{
+    code_pair_put_back::CodePairPutBack, enums::*, helper_functions::*, CodePair, DxfError,
+    DxfResult,
+};
 
 pub use crate::generated::header::*;
 
@@ -72,10 +72,7 @@ impl Header {
 
 #[cfg(test)]
 mod tests {
-    use crate::entities::*;
-    use crate::enums::*;
-    use crate::helper_functions::tests::*;
-    use crate::*;
+    use crate::{entities::*, enums::*, helper_functions::tests::*, *};
     use std::time::Duration;
 
     #[test]
@@ -188,14 +185,16 @@ mod tests {
 
     #[test]
     fn normalize_header() {
-        let mut header = Header::default();
-        header.default_text_height = -1.0; // $TEXTSIZE; normalized to 0.2
-        header.trace_width = 0.0; // $TRACEWID; normalized to 0.05
-        header.text_style = String::new(); // $TEXTSTYLE; normalized to "STANDARD"
-        header.current_layer = String::new(); // $CLAYER; normalized to "0"
-        header.current_entity_line_type = String::new(); // $CELTYPE; normalized to "BYLAYER"
-        header.dimension_style_name = String::new(); // $DIMSTYLE; normalized to "STANDARD"
-        header.file_name = String::new(); // $MENU; normalized to "."
+        let mut header = Header {
+            default_text_height: -1.0,               // $TEXTSIZE; normalized to 0.2
+            trace_width: 0.0,                        // $TRACEWID; normalized to 0.05
+            text_style: String::new(),               // $TEXTSTYLE; normalized to "STANDARD"
+            current_layer: String::new(),            // $CLAYER; normalized to "0"
+            current_entity_line_type: String::new(), // $CELTYPE; normalized to "BYLAYER"
+            dimension_style_name: String::new(),     // $DIMSTYLE; normalized to "STANDARD"
+            file_name: String::new(),                // $MENU; normalized to "."
+            ..Default::default()
+        };
         header.normalize();
         assert!(approx_eq!(f64, 0.2, header.default_text_height));
         assert!(approx_eq!(f64, 0.05, header.trace_width));

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -1,25 +1,10 @@
-use std::io;
-use std::io::Read;
-use std::time::Duration as StdDuration;
-
-extern crate byteorder;
-use self::byteorder::{ByteOrder, LittleEndian};
-
-extern crate chrono;
-use self::chrono::prelude::*;
-use self::chrono::Duration as ChronoDuration;
-
-extern crate encoding_rs;
-use self::encoding_rs::Encoding;
-
-extern crate uuid;
-use self::uuid::Uuid;
-
+use crate::{enums::*, tables::Layer, CodePair, Color, DxfError, DxfResult};
+use byteorder::{ByteOrder, LittleEndian};
+use chrono::{prelude::*, Duration as ChronoDuration};
+use encoding_rs::Encoding;
 use enum_primitive::FromPrimitive;
-
-use crate::enums::*;
-use crate::tables::Layer;
-use crate::{CodePair, Color, DxfError, DxfResult};
+use std::{io, io::Read, time::Duration as StdDuration};
+use uuid::Uuid;
 
 pub(crate) fn verify_code(pair: &CodePair, expected: i32) -> DxfResult<()> {
     if expected == pair.code {
@@ -521,8 +506,7 @@ fn parse_hex_string_test() {
 #[cfg(test)]
 #[allow(dead_code)]
 pub mod tests {
-    use crate::code_pair_iter::DirectCodePairIter;
-    use crate::*;
+    use crate::{code_pair_iter::DirectCodePairIter, *};
     use std::io::{BufRead, BufReader, Cursor, Seek, SeekFrom};
 
     pub fn unwrap_drawing(result: DxfResult<Drawing>) -> Drawing {
@@ -590,11 +574,11 @@ pub mod tests {
     }
 
     pub fn assert_contains(drawing: &Drawing, contents: String) {
-        let actual = to_test_string(&drawing);
+        let actual = to_test_string(drawing);
         assert!(actual.contains(&contents));
     }
 
-    fn try_find_index<T>(superset: &Vec<T>, subset: &Vec<T>) -> Option<usize>
+    fn try_find_index<T>(superset: &[T], subset: &[T]) -> Option<usize>
     where
         T: PartialEq,
     {
@@ -616,11 +600,11 @@ pub mod tests {
         None
     }
 
-    pub fn assert_vec_contains<T>(actual: &Vec<T>, expected: &Vec<T>)
+    pub fn assert_vec_contains<T>(actual: &[T], expected: &[T])
     where
         T: PartialEq,
     {
-        let actual_index = try_find_index(&actual, &expected);
+        let actual_index = try_find_index(actual, expected);
         assert!(actual_index.is_some());
     }
 
@@ -635,7 +619,7 @@ pub mod tests {
     }
 
     pub fn assert_not_contains(drawing: &Drawing, contents: String) {
-        let actual = to_test_string(&drawing);
+        let actual = to_test_string(drawing);
         assert!(!actual.contains(&contents));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,19 +113,11 @@
 //! (https://web.archive.org/web/20130509144333/http://usa.autodesk.com/adsk/servlet/item?siteID=123112&id=12272454&linkID=10809853)
 //!
 
-extern crate encoding_rs;
-
 #[macro_use]
 extern crate enum_primitive;
 
-extern crate image;
-extern crate itertools;
-
-#[cfg(feature = "serialize")]
 #[macro_use]
-extern crate serde_derive;
-#[cfg(feature = "serialize")]
-extern crate serde;
+mod helper_functions;
 
 mod code_pair;
 pub use crate::code_pair::CodePair;
@@ -138,9 +130,6 @@ pub use crate::data_table_value::DataTableValue;
 
 mod handle;
 pub use crate::handle::Handle;
-
-#[macro_use]
-mod helper_functions;
 
 mod dxb_item_type;
 mod dxb_reader;

--- a/src/misc_tests/encoding.rs
+++ b/src/misc_tests/encoding.rs
@@ -1,13 +1,9 @@
-use crate::entities::*;
-use crate::enums::*;
-use crate::helper_functions::tests::*;
-use crate::*;
-
-use std::io::{BufReader, Cursor, Seek, SeekFrom};
-use std::str::from_utf8;
-
-extern crate image;
-use self::image::{DynamicImage, GenericImageView};
+use crate::{entities::*, enums::*, helper_functions::tests::*, *};
+use image::{DynamicImage, GenericImageView};
+use std::{
+    io::{BufReader, Cursor, Seek, SeekFrom},
+    str::from_utf8,
+};
 
 #[test]
 fn read_string_with_control_characters() {
@@ -514,7 +510,7 @@ fn round_trip_thumbnail(thumbnail: image::DynamicImage) -> image::DynamicImage {
     let drawing_pairs = drawing.get_code_pairs().unwrap();
     assert_vec_contains(
         &drawing_pairs,
-        &vec![
+        &[
             CodePair::new_str(0, "SECTION"),
             CodePair::new_str(2, "THUMBNAILIMAGE"),
         ],

--- a/src/misc_tests/integration.rs
+++ b/src/misc_tests/integration.rs
@@ -1,15 +1,12 @@
-use crate::entities::*;
-use crate::enums::*;
-use crate::*;
-
-use std::fs::{create_dir_all, read_to_string, remove_dir_all};
-use std::path::Path;
-use std::process::Command;
-use std::thread::panicking;
-use std::time::SystemTime;
-
-extern crate glob;
+use crate::{entities::*, enums::*, *};
 use glob::glob;
+use std::{
+    fs::{create_dir_all, read_to_string, remove_dir_all},
+    path::Path,
+    process::Command,
+    thread::panicking,
+    time::SystemTime,
+};
 
 struct Oda {
     temp_path: String,

--- a/src/misc_tests/pointers.rs
+++ b/src/misc_tests/pointers.rs
@@ -1,8 +1,4 @@
-use crate::entities::*;
-use crate::enums::*;
-use crate::helper_functions::tests::*;
-use crate::objects::*;
-use crate::*;
+use crate::{entities::*, enums::*, helper_functions::tests::*, objects::*, *};
 
 #[test]
 fn follow_entity_pointer_to_object() {

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,21 +1,14 @@
 // other implementation is in `generated/objects.rs`
 
+use crate::{
+    code_pair_put_back::CodePairPutBack, enums::*, helper_functions::*, objects::*, CodePair,
+    Color, DataTableValue, DxfError, DxfResult, Point, SectionTypeSettings, TableCellStyle,
+    TransformationMatrix,
+};
+use chrono::Duration;
 use enum_primitive::FromPrimitive;
 use itertools::Itertools;
 use std::ops::Add;
-
-extern crate chrono;
-use self::chrono::Duration;
-
-use crate::{
-    CodePair, Color, DataTableValue, DxfError, DxfResult, Point, SectionTypeSettings,
-    TableCellStyle, TransformationMatrix,
-};
-
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::enums::*;
-use crate::helper_functions::*;
-use crate::objects::*;
 
 //------------------------------------------------------------------------------
 //                                                                  GeoMeshPoint
@@ -157,8 +150,8 @@ impl Object {
         }
     }
     fn apply_code_pair(&mut self, pair: &CodePair, iter: &mut CodePairPutBack) -> DxfResult<()> {
-        if !self.specific.try_apply_code_pair(&pair)? {
-            self.common.apply_individual_pair(&pair, iter)?;
+        if !self.specific.try_apply_code_pair(pair)? {
+            self.common.apply_individual_pair(pair, iter)?;
         }
         Ok(())
     }
@@ -1654,7 +1647,7 @@ impl Object {
 
         true
     }
-    fn add_post_code_pairs(&self, _pairs: &mut Vec<CodePair>, _version: AcadVersion) {
+    fn add_post_code_pairs(&self, _pairs: &mut [CodePair], _version: AcadVersion) {
         // use the following pattern if this method is needed
         // match self.specific {
         //     _ => (),
@@ -1664,10 +1657,7 @@ impl Object {
 
 #[cfg(test)]
 mod tests {
-    use crate::enums::*;
-    use crate::helper_functions::tests::*;
-    use crate::objects::*;
-    use crate::*;
+    use crate::{enums::*, helper_functions::tests::*, objects::*, *};
 
     fn read_object(object_type: &str, body: Vec<CodePair>) -> Object {
         let mut pairs = vec![CodePair::new_str(0, object_type)];

--- a/src/object_iter.rs
+++ b/src/object_iter.rs
@@ -1,5 +1,4 @@
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::objects::Object;
+use crate::{code_pair_put_back::CodePairPutBack, objects::Object};
 
 pub(crate) struct ObjectIter<'a> {
     pub iter: &'a mut CodePairPutBack,

--- a/src/section_type_settings.rs
+++ b/src/section_type_settings.rs
@@ -1,7 +1,6 @@
 use crate::{CodePair, DxfResult, Handle, SectionGeometrySettings};
 
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::helper_functions::*;
+use crate::{code_pair_put_back::CodePairPutBack, helper_functions::*};
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,6 +1,4 @@
-use crate::helper_functions::*;
-use crate::tables::*;
-use crate::Color;
+use crate::{helper_functions::*, tables::*, Color};
 
 //------------------------------------------------------------------------------
 //                                                                         Layer
@@ -61,12 +59,7 @@ impl ViewPort {
 
 #[cfg(test)]
 mod tests {
-    use crate::entities::*;
-    use crate::enums::*;
-    use crate::helper_functions::tests::*;
-    use crate::objects::*;
-    use crate::tables::*;
-    use crate::*;
+    use crate::{entities::*, enums::*, helper_functions::tests::*, objects::*, tables::*, *};
 
     fn read_table(table_name: &str, value_pairs: Vec<CodePair>) -> Drawing {
         let mut pairs = vec![
@@ -181,9 +174,11 @@ mod tests {
     #[test]
     fn write_layer() {
         let mut drawing = Drawing::new();
-        let mut layer = Layer::default();
-        layer.name = String::from("layer-name");
-        layer.color = Color::from_index(3);
+        let layer = Layer {
+            name: String::from("layer-name"),
+            color: Color::from_index(3),
+            ..Default::default()
+        };
         drawing.add_layer(layer);
         assert_contains_pairs(
             &drawing,
@@ -202,10 +197,12 @@ mod tests {
 
     #[test]
     fn normalize_layer() {
-        let mut layer = Layer::default();
-        layer.name = String::from("layer-name");
-        layer.color = Color::by_layer(); // value 256 not valid; normalized to 7
-        layer.line_type_name = String::from(""); // empty string not valid; normalized to CONTINUOUS
+        let mut layer = Layer {
+            name: String::from("layer-name"),
+            color: Color::by_layer(), // value 256 not valid; normalized to 7
+            line_type_name: String::from(""), // empty string not valid; normalized to CONTINUOUS
+            ..Default::default()
+        };
         layer.normalize();
         assert_eq!(Some(7), layer.color.index());
         assert_eq!("CONTINUOUS", layer.line_type_name);
@@ -213,10 +210,12 @@ mod tests {
 
     #[test]
     fn normalize_view() {
-        let mut view = View::default();
-        view.view_height = 0.0; // invalid; normalized to 1.0
-        view.view_width = -1.0; // invalid; normalized to 1.0
-        view.lens_length = 42.0; // valid
+        let mut view = View {
+            view_height: 0.0,  // invalid; normalized to 1.0
+            view_width: -1.0,  // invalid; normalized to 1.0
+            lens_length: 42.0, // valid
+            ..Default::default()
+        };
         view.normalize();
         assert!(approx_eq!(f64, 1.0, view.view_height));
         assert!(approx_eq!(f64, 1.0, view.view_width));

--- a/src/table_cell_style.rs
+++ b/src/table_cell_style.rs
@@ -1,7 +1,6 @@
 use crate::{CodePair, Color, DxfResult};
 
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::helper_functions::*;
+use crate::{code_pair_put_back::CodePairPutBack, helper_functions::*};
 
 /// Defines a style for a table's cell.
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -73,14 +73,14 @@ fn read_thumbnail_bytes_from_code_pairs(iter: &mut CodePairPutBack) -> DxfResult
     Ok(Some(data))
 }
 
-fn update_thumbnail_data_offset_in_situ(data: &mut Vec<u8>) -> DxfResult<bool> {
+fn update_thumbnail_data_offset_in_situ(data: &mut [u8]) -> DxfResult<bool> {
     // calculate the image data offset
-    let dib_header_size = get_i32(&data, FILE_HEADER_LENGTH)? as usize;
+    let dib_header_size = get_i32(data, FILE_HEADER_LENGTH)? as usize;
 
     // calculate the palette size
     let palette_size = if dib_header_size >= BITMAP_HEADER_PALETTE_COUNT_OFFSET + 4 {
         let palette_color_count = get_u32(
-            &data,
+            data,
             FILE_HEADER_LENGTH + BITMAP_HEADER_PALETTE_COUNT_OFFSET,
         )? as usize;
         palette_color_count * 4 // always 4 bytes: BGRA
@@ -196,7 +196,7 @@ fn set_thumbnail_offset_for_bitmapv4header_palette_256() {
 }
 
 fn read_thumbnail_from_bytes(data: &[u8]) -> DxfResult<Option<image::DynamicImage>> {
-    let image = image::load_from_memory(&data)?;
+    let image = image::load_from_memory(data)?;
     Ok(Some(image))
 }
 
@@ -240,7 +240,7 @@ fn test_get_u32() {
     assert_eq!(0x12345678, value);
 }
 
-fn set_i32(data: &mut Vec<u8>, offset: usize, value: i32) -> DxfResult<()> {
+fn set_i32(data: &mut [u8], offset: usize, value: i32) -> DxfResult<()> {
     let expected_length = offset + 4;
     if data.len() < expected_length {
         return Err(DxfError::UnexpectedEndOfInput);

--- a/src/x_data.rs
+++ b/src/x_data.rs
@@ -1,8 +1,6 @@
 use crate::{CodePair, DxfError, DxfResult, Handle, Point, Vector};
 
-use crate::code_pair_put_back::CodePairPutBack;
-use crate::enums::AcadVersion;
-use crate::helper_functions::*;
+use crate::{code_pair_put_back::CodePairPutBack, enums::AcadVersion, helper_functions::*};
 
 pub(crate) const XDATA_APPLICATIONNAME: i32 = 1001;
 const XDATA_STRING: i32 = 1000;
@@ -243,12 +241,14 @@ impl XDataItem {
 
 #[cfg(test)]
 mod tests {
-    use crate::code_pair::CodePair;
-    use crate::enums::AcadVersion;
-    use crate::helper_functions::tests::*;
-    use crate::objects::*;
-    use crate::x_data::{XData, XDataItem};
-    use crate::{Drawing, Point, Vector};
+    use crate::{
+        code_pair::CodePair,
+        enums::AcadVersion,
+        helper_functions::tests::*,
+        objects::*,
+        x_data::{XData, XDataItem},
+        Drawing, Point, Vector,
+    };
 
     fn read_x_data_items(values: Vec<CodePair>) -> Vec<XDataItem> {
         let mut pairs = vec![


### PR DESCRIPTION
Thanks for making this crate!

I updated all the dependencies and migrated to rust edition 2021.
When running `clippy` I ran into a lot of warnings. I've fixed almost all of them, except for the ones in the generated files. For those I added a `#[allow(clippy::all)]` in `src/generated.rs` to silence clippy. Some of these errors came from the `.xml` files and I didn't want to mess with those.