### PR TITLE
Code "100" is still required in some dxf files, so keep reading after this code.

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -1461,6 +1461,7 @@ impl Object {
 
                 match pair.code {
                     100 => {
+                        reading_data = true;
                         continue;
                     } // value should be "AcDbXrecord", but it doesn't really matter
                     5 | 105 => (), // these codes aren't allowed here

--- a/src/object.rs
+++ b/src/object.rs
@@ -1463,7 +1463,7 @@ impl Object {
                     100 => {
                         reading_data = true;
                         continue;
-                    } // value should be "AcDbXrecord", but it doesn't really matter
+                    } // value should be "AcDbXrecord", some dxf files still need to keep the object read
                     5 | 105 => (), // these codes aren't allowed here
                     _ => {
                         xr.data_pairs.push(pair);


### PR DESCRIPTION
I found that in some dxf files, the code ```100``` needs to keep ```object``` read.
```
  0
XRECORD
  5
34F9
102
{ACAD_REACTORS
330
34F8
102
}
330
34F8
100
AcDbXrecord
```