### PR TITLE
Bump uuid dep for wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ itertools = "0.10.0"
 num = "0.3.1"
 serde = { version = "1.*.*", optional = true }
 serde_derive = { version = "1.*.*", optional = true }
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.3.3", features = ["serde", "v4"] }
 
 [build-dependencies]
 xmltree = "0.8.0"


### PR DESCRIPTION
Increments the `uuid` dependency to the latest version, which supports compiling to `wasm32-unknown-unknown` with a feature flag.

Downstream users would enable this by adding a UUID dependency to their `Cargo.toml`:
```toml
uuid = { version = "1", features = ["js"] }
```