### PR TITLE
Removed Option return for read_line

### DIFF
--- a/src/code_pair_iter.rs
+++ b/src/code_pair_iter.rs
@@ -83,9 +83,8 @@ impl<T: Read> TextCodePairIter<T> {
         let code_line = if self.read_first_line {
             self.offset += 1;
             match read_line(&mut self.reader, true, encoding_rs::WINDOWS_1252) {
-                Some(Ok(v)) => v,
-                Some(Err(e)) => return Some(Err(e)),
-                None => return None,
+                Ok(v) => v,
+                Err(e) => return Some(Err(e)),
             }
         } else {
             self.read_first_line = true;
@@ -106,9 +105,8 @@ impl<T: Read> TextCodePairIter<T> {
         // Read value.  If no line is available die horribly.
         self.offset += 1;
         let value_line = match read_line(&mut self.reader, false, self.string_encoding) {
-            Some(Ok(v)) => v,
-            Some(Err(e)) => return Some(Err(e)),
-            None => return Some(Err(DxfError::UnexpectedEndOfInput)),
+            Ok(v) => v,
+            Err(e) => return Some(Err(e)),
         };
 
         // construct the value pair

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -115,11 +115,7 @@ impl Drawing {
     where
         T: Read + ?Sized,
     {
-        let first_line = match read_line(reader, true, encoding) {
-            Some(Ok(line)) => line,
-            Some(Err(e)) => return Err(e),
-            None => return Err(DxfError::UnexpectedEndOfInput),
-        };
+        let first_line = read_line(reader, true, encoding)?;
         match &*first_line {
             "AutoCAD DXB 1.0" => {
                 let mut reader = DxbReader::new(reader);

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -299,7 +299,7 @@ pub(crate) fn read_line<T>(
     reader: &mut T,
     allow_bom: bool,
     encoding: &'static Encoding,
-) -> Option<DxfResult<String>>
+) -> DxfResult<String>
 where
     T: Read + ?Sized,
 {
@@ -309,7 +309,7 @@ where
     for (i, b) in reader_bytes.enumerate() {
         let b = match b {
             Ok(b) => b,
-            Err(e) => return Some(Err(DxfError::IoError(e))),
+            Err(e) => return Err(DxfError::IoError(e)),
         };
         match (i, b) {
             (0, 0xEF) if allow_bom => {
@@ -327,14 +327,14 @@ where
 
     let mut result = match encoding.decode(&bytes) {
         (result, _, false) => String::from(&*result),
-        (_, _, true) => return Some(Err(DxfError::MalformedString)),
+        (_, _, true) => return Err(DxfError::MalformedString),
     };
 
     if result.ends_with('\r') {
         result.pop();
     }
 
-    Some(Ok(result))
+    Ok(result)
 }
 
 pub(crate) fn read_u8<T: Read + ?Sized>(reader: &mut T) -> Option<io::Result<u8>> {


### PR DESCRIPTION
For `helper_functions::read_line` the Option return is not needed as the function always returns `Some(..)` just wraps either `Ok(..)` or `Err(..)`.

With this change the functions where `helper_functions::read_line` is called have simpler unwrapping.