### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ uuid = { version = "1.3.3", features = ["serde", "v4"] }
 xmltree = "0.8.0"
 
 [dev-dependencies]
-float-cmp = "0.8.0"
+float-cmp = "0.9.0"
 glob = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.3.4"
 chrono = { version= "0.4.19", features = ["serde"] }
 encoding_rs = "0.8.26"
 enum_primitive = "0.1.1"
-image = "0.23.12"
+image = "0.24"
 itertools = "0.11"
 num = "0.4"
 serde = { version = "1.*.*", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ encoding_rs = "0.8.26"
 enum_primitive = "0.1.1"
 image = "0.23.12"
 itertools = "0.10.0"
-num = "0.3.1"
+num = "0.4"
 serde = { version = "1.*.*", optional = true }
 serde_derive = { version = "1.*.*", optional = true }
 uuid = { version = "1.3.3", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version= "0.4.19", features = ["serde"] }
 encoding_rs = "0.8.26"
 enum_primitive = "0.1.1"
 image = "0.23.12"
-itertools = "0.10.0"
+itertools = "0.11"
 num = "0.4"
 serde = { version = "1.*.*", optional = true }
 serde_derive = { version = "1.*.*", optional = true }

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -29,7 +29,7 @@ use crate::code_pair_writer::CodePairWriter;
 use crate::thumbnail;
 
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Cursor, Read, Write};
 
 use itertools::put_back;
 use std::collections::HashSet;
@@ -964,7 +964,7 @@ impl Drawing {
                 pairs.push(CodePair::new_str(0, "SECTION"));
                 pairs.push(CodePair::new_str(2, "THUMBNAILIMAGE"));
                 let mut data = vec![];
-                img.write_to(&mut data, image::ImageFormat::Bmp)?;
+                img.write_to(&mut Cursor::new(&mut data), image::ImageFormat::Bmp)?;
                 let length = data.len() - 14; // skip 14 byte bmp header
                 pairs.push(CodePair::new_i32(90, length as i32));
                 for s in data[14..].chunks(128) {


### PR DESCRIPTION
This updates deps that are outdated, except `xmltree`, because that one requires more work.

A simple change had to be made for the `image` crate update to wrap the destination `Vec` in a `io::Cursor` because the method call now needs the argument to implement `Seek`.