### PR TITLE
Update serde derives.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 targets = []
 
 [features]
-serialize = ["serde", "serde_derive"]
+serialize = ["serde"]
 
 [dependencies]
 byteorder = "1.3.4"
@@ -25,8 +25,7 @@ enum_primitive = "0.1.1"
 image = "0.24"
 itertools = "0.11"
 num = "0.4"
-serde = { version = "1.*.*", optional = true }
-serde_derive = { version = "1.*.*", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
 
 [build-dependencies]

--- a/build/entity_generator.rs
+++ b/build/entity_generator.rs
@@ -66,7 +66,9 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
         panic!("Expected first entity to be 'Entity'.");
     }
     fun.push_str("#[derive(Debug, Clone)]\n");
-    fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+    fun.push_str(
+        "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
+    );
     fun.push_str("pub struct EntityCommon {\n");
     for c in &entity.children {
         let t = if allow_multiples(c) {
@@ -107,7 +109,9 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
     fun.push('\n');
 
     fun.push_str("#[derive(Debug, Clone)]\n");
-    fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+    fun.push_str(
+        "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
+    );
     fun.push_str("pub struct Entity {\n");
     fun.push_str("    pub common: EntityCommon,\n");
     fun.push_str("    pub specific: EntityType,\n");
@@ -209,7 +213,9 @@ fn generate_base_entity(fun: &mut String, element: &Element) {
 
 fn generate_entity_types(fun: &mut String, element: &Element) {
     fun.push_str("#[derive(Clone, Debug, PartialEq)]\n");
-    fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+    fun.push_str(
+        "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
+    );
     fun.push_str("pub enum EntityType {\n");
     for c in &element.children {
         if c.name != "Entity" {
@@ -231,7 +237,7 @@ fn generate_entity_types(fun: &mut String, element: &Element) {
         if name(c) != "Entity" {
             // definition
             fun.push_str("#[derive(Clone, Debug, PartialEq)]\n");
-            fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+            fun.push_str("#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n");
             fun.push_str(&format!("pub struct {typ} {{\n", typ = name(c)));
             if base_class(c) == "DimensionBase" {
                 fun.push_str("    pub dimension_base: DimensionBase,\n");

--- a/build/header_generator.rs
+++ b/build/header_generator.rs
@@ -60,7 +60,9 @@ use self::uuid::Uuid;
 fn generate_struct(fun: &mut String, element: &Element) {
     let mut seen_fields = HashSet::new();
     fun.push_str("/// Contains common properties for the DXF file.\n");
-    fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+    fun.push_str(
+        "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
+    );
     fun.push_str("pub struct Header {\n");
     for v in &element.children {
         let field_name = field(v);

--- a/build/object_generator.rs
+++ b/build/object_generator.rs
@@ -73,7 +73,9 @@ fn generate_base_object(fun: &mut String, element: &Element) {
         panic!("Expected first object to be 'Object'.");
     }
     fun.push_str("#[derive(Clone, Debug)]\n");
-    fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+    fun.push_str(
+        "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
+    );
     fun.push_str("pub struct ObjectCommon {\n");
     for c in &object.children {
         let t = if allow_multiples(c) {
@@ -114,7 +116,9 @@ fn generate_base_object(fun: &mut String, element: &Element) {
     fun.push('\n');
 
     fun.push_str("#[derive(Clone, Debug)]\n");
-    fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+    fun.push_str(
+        "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
+    );
     fun.push_str("pub struct Object {\n");
     fun.push_str("    pub common: ObjectCommon,\n");
     fun.push_str("    pub specific: ObjectType,\n");
@@ -219,7 +223,9 @@ fn generate_base_object(fun: &mut String, element: &Element) {
 fn generate_object_types(fun: &mut String, element: &Element) {
     fun.push_str("#[allow(clippy::large_enum_variant)]\n");
     fun.push_str("#[derive(Clone, Debug, PartialEq)]\n");
-    fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+    fun.push_str(
+        "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
+    );
     fun.push_str("pub enum ObjectType {\n");
     for c in &element.children {
         if c.name != "Object" {
@@ -241,7 +247,7 @@ fn generate_object_types(fun: &mut String, element: &Element) {
         if name(c) != "Object" {
             // definition
             fun.push_str("#[derive(Clone, Debug, PartialEq)]\n");
-            fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+            fun.push_str("#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n");
             fun.push_str(&format!("pub struct {typ} {{\n", typ = name(c)));
             for f in &c.children {
                 let t = if allow_multiples(f) {

--- a/build/table_generator.rs
+++ b/build/table_generator.rs
@@ -57,7 +57,9 @@ fn generate_table_items(fun: &mut String, element: &Element) {
         let mut seen_fields = HashSet::new();
         let table_item = &table.children[0];
         fun.push_str("#[derive(Debug)]\n");
-        fun.push_str("#[cfg_attr(feature = \"serialize\", derive(Serialize, Deserialize))]\n");
+        fun.push_str(
+            "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
+        );
         fun.push_str(&format!("pub struct {name} {{\n", name = name(table_item)));
         fun.push_str("    pub name: String,\n");
         fun.push_str("    pub handle: Handle,\n");

--- a/src/block.rs
+++ b/src/block.rs
@@ -13,7 +13,7 @@ use crate::x_data;
 
 /// A block is a collection of entities.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Block {
     /// The block's handle.
     pub handle: Handle,

--- a/src/class.rs
+++ b/src/class.rs
@@ -6,7 +6,7 @@ use crate::helper_functions::*;
 
 /// Represents an application-defined class whose instances are `Block`s, `Entity`s, and `Object`s.
 #[derive(Clone)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Class {
     /// Class DXF record name.
     pub record_name: String,

--- a/src/code_pair.rs
+++ b/src/code_pair.rs
@@ -12,7 +12,7 @@ use crate::helper_functions::parse_hex_string;
 /// The basic primitive of a DXF file; a code indicating the type of the data contained, and the
 /// data itself.
 #[derive(Clone)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CodePair {
     pub code: i32,
     pub value: CodePairValue,

--- a/src/code_pair_value.rs
+++ b/src/code_pair_value.rs
@@ -4,7 +4,7 @@ use std::fmt::{Debug, Display, Formatter};
 
 /// Contains the data portion of a `CodePair`.
 #[derive(PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum CodePairValue {
     Boolean(i16),
     Integer(i32),

--- a/src/color.rs
+++ b/src/color.rs
@@ -2,7 +2,7 @@ use crate::tables::Layer;
 
 /// Represents an indexed color.
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     raw_value: i16,
 }

--- a/src/data_table_value.rs
+++ b/src/data_table_value.rs
@@ -1,7 +1,7 @@
 use crate::{Handle, Point};
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DataTableValue {
     Boolean(bool),
     Integer(i32),

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -39,7 +39,7 @@ use std::path::Path;
 pub(crate) const AUTO_REPLACE_HANDLE: Handle = Handle(0xFFFF_FFFF_FFFF_FFFF);
 
 /// Represents a DXF drawing.
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Drawing {
     /// The drawing's header.  Contains various drawing-specific values and settings.
     pub header: Header,

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -118,7 +118,7 @@ impl Line {
 //------------------------------------------------------------------------------
 /// Represents a single vertex of a `LwPolyline`.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct LwPolylineVertex {
     pub x: f64,
     pub y: f64,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -6,7 +6,7 @@ use std::fmt;
 enum_from_primitive! {
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Dwf3DPrecision {
     Deviation_1 = 1,
     Deviation_0_5 = 2,
@@ -19,7 +19,7 @@ pub enum Dwf3DPrecision {
 
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum AcadVersion {
     Version_1_0,
     Version_1_2,
@@ -129,7 +129,7 @@ impl fmt::Display for AcadVersion {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum AngleDirection {
     CounterClockwise = 0,
     Clockwise = 1,
@@ -138,7 +138,7 @@ pub enum AngleDirection {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum AngleFormat {
     DecimalDegrees = 0,
     DegreesMinutesSeconds = 1,
@@ -150,7 +150,7 @@ pub enum AngleFormat {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum AttachmentPoint {
     TopLeft = 1,
     TopCenter = 2,
@@ -166,7 +166,7 @@ pub enum AttachmentPoint {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum AttributeVisibility {
     None = 0,
     Normal = 1,
@@ -176,7 +176,7 @@ pub enum AttributeVisibility {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum BackgroundFillSetting {
     Off = 0,
     UseBackgroundFillColor = 1,
@@ -186,7 +186,7 @@ pub enum BackgroundFillSetting {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum BottomTextAttachmentDirection {
     Center = 9,
     UnderlineAndCenter = 10,
@@ -195,7 +195,7 @@ pub enum BottomTextAttachmentDirection {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum CoordinateDisplay {
     Static = 0,
     ContinuousUpdate = 1,
@@ -205,7 +205,7 @@ pub enum CoordinateDisplay {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DefaultLightingType
 {
     OneDistantLight = 0,
@@ -215,7 +215,7 @@ pub enum DefaultLightingType
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DesignCoordinateType
 {
     Unknown = 0,
@@ -227,7 +227,7 @@ pub enum DesignCoordinateType
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DiagnosticBSPMode
 {
     Depth = 0,
@@ -237,7 +237,7 @@ pub enum DiagnosticBSPMode
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DiagnosticPhotonMode
 {
     Density = 0,
@@ -247,7 +247,7 @@ pub enum DiagnosticPhotonMode
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DictionaryDuplicateRecordHandling
 {
     NotApplicable = 0,
@@ -261,7 +261,7 @@ pub enum DictionaryDuplicateRecordHandling
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DimensionArcSymbolDisplayMode {
     SymbolBeforeText = 0,
     SymbolAboveText = 1,
@@ -271,7 +271,7 @@ pub enum DimensionArcSymbolDisplayMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DimensionAssociativity {
     NoAssociationExploded = 0,
     NonAssociativeObjects = 1,
@@ -281,7 +281,7 @@ pub enum DimensionAssociativity {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DimensionFit {
     TextAndArrowsOutsideLines = 0,
     MoveArrowsFirst = 1,
@@ -292,7 +292,7 @@ pub enum DimensionFit {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DimensionFractionFormat {
     HorizontalStacking = 0,
     DiagonalStacking = 1,
@@ -302,7 +302,7 @@ pub enum DimensionFractionFormat {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DimensionTextBackgroundColorMode {
     None = 0,
     UseDrawingBackground = 1,
@@ -312,7 +312,7 @@ pub enum DimensionTextBackgroundColorMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DimensionTextJustification {
     AboveLineCenter = 0,
     AboveLineNextToFirstExtension = 1,
@@ -324,7 +324,7 @@ pub enum DimensionTextJustification {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DimensionTextMovementRule {
     MoveLineWithText = 0,
     AddLeaderWhenTextIsMoved = 1,
@@ -334,7 +334,7 @@ pub enum DimensionTextMovementRule {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DimensionType {
     RotatedHorizontalOrVertical = 0,
     Aligned = 1,
@@ -348,7 +348,7 @@ pub enum DimensionType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DragMode {
     Off = 0,
     On = 1,
@@ -358,7 +358,7 @@ pub enum DragMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DrawingDirection {
     LeftToRight = 1,
     TopToBottom = 3,
@@ -368,7 +368,7 @@ pub enum DrawingDirection {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum DrawingUnits {
     English = 0,
     Metric = 1,
@@ -377,7 +377,7 @@ pub enum DrawingUnits {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum EdgeStyleModel
 {
     NoEdges = 0,
@@ -388,7 +388,7 @@ pub enum EdgeStyleModel
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum EndCapSetting {
     None = 0,
     Round = 1,
@@ -399,7 +399,7 @@ pub enum EndCapSetting {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FaceColorMode
 {
     NoColor = 0,
@@ -414,7 +414,7 @@ pub enum FaceColorMode
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FaceLightingModel
 {
     Invisible = 0,
@@ -426,7 +426,7 @@ pub enum FaceLightingModel
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FaceLightingQuality
 {
     None = 0,
@@ -437,7 +437,7 @@ pub enum FaceLightingQuality
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FaceModifier
 {
     None = 0,
@@ -448,7 +448,7 @@ pub enum FaceModifier
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FlowDirection
 {
     Down = 0,
@@ -458,7 +458,7 @@ pub enum FlowDirection
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FontType {
     TTF = 0,
     SHX = 1,
@@ -467,7 +467,7 @@ pub enum FontType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum GeoDataVersion
 {
     R2009 = 1,
@@ -477,7 +477,7 @@ pub enum GeoDataVersion
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum HelixConstraint {
     ConstrainTurnHeight = 0,
     ConstrainTurns = 1,
@@ -487,7 +487,7 @@ pub enum HelixConstraint {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum HorizontalTextJustification {
     Left = 0,
     Center = 1,
@@ -500,7 +500,7 @@ pub enum HorizontalTextJustification {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ImageClippingBoundaryType {
     Rectangular = 1,
     Polygonal = 2,
@@ -509,7 +509,7 @@ pub enum ImageClippingBoundaryType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ImageResolutionUnits
 {
     NoUnits = 0,
@@ -520,7 +520,7 @@ pub enum ImageResolutionUnits
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum JoinStyle {
     None = 0,
     Round = 1,
@@ -531,7 +531,7 @@ pub enum JoinStyle {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Justification {
     Top = 0,
     Middle = 1,
@@ -541,7 +541,7 @@ pub enum Justification {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LayerAndSpatialIndexSaveMode {
     None = 0,
     LayerIndex = 1,
@@ -552,7 +552,7 @@ pub enum LayerAndSpatialIndexSaveMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LeaderCreationAnnotationType {
     WithTextAnnotation = 0,
     WithToleranceAnnotation = 1,
@@ -563,7 +563,7 @@ pub enum LeaderCreationAnnotationType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LeaderHooklineDirection {
     OppositeFromHorizontalVector = 0,
     SameAsHorizontalVector = 1,
@@ -572,7 +572,7 @@ pub enum LeaderHooklineDirection {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LeaderPathType {
     StraightLineSegments = 0,
     Spline = 1,
@@ -581,7 +581,7 @@ pub enum LeaderPathType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LightAttenuationType {
     None = 0,
     InverseLinear = 1,
@@ -591,7 +591,7 @@ pub enum LightAttenuationType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LightType {
     Distant = 1,
     Point = 2,
@@ -601,7 +601,7 @@ pub enum LightType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LineTypeStyle {
     Off = 0,
     Solid = 1,
@@ -620,7 +620,7 @@ pub enum LineTypeStyle {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LoftedObjectNormalMode {
     Ruled = 0,
     SmoothFit = 1,
@@ -634,7 +634,7 @@ pub enum LoftedObjectNormalMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MapAutoTransformMethod
 {
     NoAutoTransform = 1,
@@ -645,7 +645,7 @@ pub enum MapAutoTransformMethod
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MapProjectionMethod
 {
     Planar = 1,
@@ -657,7 +657,7 @@ pub enum MapProjectionMethod
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MapTilingMethod
 {
     Tile = 1,
@@ -668,7 +668,7 @@ pub enum MapTilingMethod
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MTextFlag {
     MultilineAttribute = 2,
     ConstantMultilineAttributeDefinition = 4,
@@ -677,7 +677,7 @@ pub enum MTextFlag {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MTextLineSpacingStyle {
     AtLeast = 1,
     Exact = 2,
@@ -686,7 +686,7 @@ pub enum MTextLineSpacingStyle {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum NonAngularUnits {
     Scientific = 1,
     Decimal = 2,
@@ -699,7 +699,7 @@ pub enum NonAngularUnits {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ObjectOsnapType
 {
     None = 0,
@@ -721,7 +721,7 @@ pub enum ObjectOsnapType
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum OleObjectType {
     Link = 1,
     Embedded = 2,
@@ -731,7 +731,7 @@ pub enum OleObjectType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum OrthographicViewType {
     None = 0,
     Top = 1,
@@ -745,7 +745,7 @@ pub enum OrthographicViewType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum PickStyle {
     None = 0,
     Group = 1,
@@ -756,7 +756,7 @@ pub enum PickStyle {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum PlotPaperUnits
 {
     Inches = 0,
@@ -767,7 +767,7 @@ pub enum PlotPaperUnits
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum PlotRotation
 {
     NoRotation = 0,
@@ -779,7 +779,7 @@ pub enum PlotRotation
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum PlotStyle {
     ByLayer = 0,
     ByBlock = 1,
@@ -790,7 +790,7 @@ pub enum PlotStyle {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum PlotType
 {
     LastScreenDisplay = 0,
@@ -804,7 +804,7 @@ pub enum PlotType
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum PolylineCurvedAndSmoothSurfaceType {
     None = 0,
     QuadraticBSpline = 5,
@@ -815,7 +815,7 @@ pub enum PolylineCurvedAndSmoothSurfaceType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum PolySketchMode {
     SketchLines = 0,
     SketchPolylines = 1,
@@ -824,7 +824,7 @@ pub enum PolySketchMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RasterImageUnits
 {
     None = 0,
@@ -841,7 +841,7 @@ pub enum RasterImageUnits
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderAccuracy
 {
     Low = 0,
@@ -852,7 +852,7 @@ pub enum RenderAccuracy
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderDestination
 {
     RenderWindow = 0,
@@ -862,7 +862,7 @@ pub enum RenderDestination
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderDiagnosticGridMode
 {
     Object = 0,
@@ -873,7 +873,7 @@ pub enum RenderDiagnosticGridMode
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderDiagnosticMode
 {
     Off = 0,
@@ -885,7 +885,7 @@ pub enum RenderDiagnosticMode
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderDuration
 {
     ByTime = 0,
@@ -896,7 +896,7 @@ pub enum RenderDuration
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderProcedure
 {
     View = 0,
@@ -907,7 +907,7 @@ pub enum RenderProcedure
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderShadowMode
 {
     Simple = 0,
@@ -918,7 +918,7 @@ pub enum RenderShadowMode
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum RotatedDimensionType
 {
     Parallel = 0,
@@ -928,7 +928,7 @@ pub enum RotatedDimensionType
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum SamplingFilterType
 {
     Box = 0,
@@ -941,7 +941,7 @@ pub enum SamplingFilterType
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ScaleEstimationMethod
 {
     None = 1,
@@ -953,7 +953,7 @@ pub enum ScaleEstimationMethod
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ShadeEdgeMode {
     FacesShadedEdgeNotHighlighted = 0,
     FacesShadedEdgesHighlightedInBlack = 1,
@@ -964,7 +964,7 @@ pub enum ShadeEdgeMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ShadePlotMode
 {
     AsDisplayed = 0,
@@ -976,7 +976,7 @@ pub enum ShadePlotMode
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ShadePlotResolutionLevel
 {
     Draft = 0,
@@ -990,7 +990,7 @@ pub enum ShadePlotResolutionLevel
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ShadowMode {
     CastsAndReceivesShadows = 0,
     CastsShadows = 1,
@@ -1001,7 +1001,7 @@ pub enum ShadowMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ShadowType {
     RayTraced = 0,
     ShadowMaps = 1,
@@ -1010,7 +1010,7 @@ pub enum ShadowType {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum SnapIsometricPlane {
     Left = 0,
     Top = 1,
@@ -1020,7 +1020,7 @@ pub enum SnapIsometricPlane {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum SnapStyle {
     Standard = 0,
     Isometric = 1,
@@ -1029,7 +1029,7 @@ pub enum SnapStyle {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum SolidHistoryMode {
     None = 0,
     DoesNotOverride = 1,
@@ -1039,7 +1039,7 @@ pub enum SolidHistoryMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum StandardScale
 {
@@ -1081,7 +1081,7 @@ pub enum StandardScale
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum SubentityType
 {
     Edge = 1,
@@ -1091,7 +1091,7 @@ pub enum SubentityType
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextAttachmentDirection {
     Horizontal = 0,
     Vertical = 1,
@@ -1100,7 +1100,7 @@ pub enum TextAttachmentDirection {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextDirection {
     LeftToRight = 0,
     RightToLeft = 1,
@@ -1109,7 +1109,7 @@ pub enum TextDirection {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextLineSpacingStyle {
     AtLeast = 1,
     Exact = 2,
@@ -1118,7 +1118,7 @@ pub enum TextLineSpacingStyle {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum TileModeDescriptor {
     InTiledViewport = 0,
     InNonTiledViewport = 1,
@@ -1127,7 +1127,7 @@ pub enum TileModeDescriptor {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum TileOrder
 {
     Hilbert = 0,
@@ -1141,7 +1141,7 @@ pub enum TileOrder
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum UcsOrthographicType
 {
     NotOrthographic = 0,
@@ -1156,7 +1156,7 @@ pub enum UcsOrthographicType
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum DrawingTimeZone {
     InternationalDateLineWest = -12000,
@@ -1241,7 +1241,7 @@ pub enum DrawingTimeZone {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum TopTextAttachmentDirection {
     Center = 9,
     OverlineAndCenter = 10,
@@ -1250,7 +1250,7 @@ pub enum TopTextAttachmentDirection {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum UnderlayFrameMode {
     None = 0,
     DisplayAndPlot = 1,
@@ -1260,7 +1260,7 @@ pub enum UnderlayFrameMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum UnitFormat {
     Scientific = 1,
     Decimal = 2,
@@ -1274,7 +1274,7 @@ pub enum UnitFormat {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Units {
     Unitless = 0,
     Inches = 1,
@@ -1305,7 +1305,7 @@ pub enum Units {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ViewMode {
     flags: i32,
 }
@@ -1363,7 +1363,7 @@ impl ViewMode {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ViewRenderMode
 {
     Classic2D = 0,
@@ -1378,7 +1378,7 @@ pub enum ViewRenderMode
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Version {
     R2010 = 0,
 }
@@ -1386,7 +1386,7 @@ pub enum Version {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum VerticalTextJustification {
     Baseline = 0,
     Bottom = 1,
@@ -1397,7 +1397,7 @@ pub enum VerticalTextJustification {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum XrefClippingBoundaryVisibility {
     NotDisplayedNotPlotted = 0,
     DisplayedAndPlotted = 1,
@@ -1407,7 +1407,7 @@ pub enum XrefClippingBoundaryVisibility {
 
 enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum UnitZeroSuppression {
     SuppressZeroFeetAndZeroInches = 0,
     IncludeZeroFeetAndZeroInches = 1,

--- a/src/extension_data.rs
+++ b/src/extension_data.rs
@@ -6,7 +6,7 @@ pub(crate) const EXTENSION_DATA_GROUP: i32 = 102;
 
 /// Represents an application name and a collection of extension group data in the form of `CodePair`s.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtensionGroup {
     pub application_name: String,
     pub items: Vec<ExtensionGroupItem>,
@@ -14,7 +14,7 @@ pub struct ExtensionGroup {
 
 /// Represents a single piece of extension data or a named group.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExtensionGroupItem {
     CodePair(CodePair),
     Group(ExtensionGroup),

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Handle(pub u64);
 
 impl Handle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,12 +121,6 @@ extern crate enum_primitive;
 extern crate image;
 extern crate itertools;
 
-#[cfg(feature = "serialize")]
-#[macro_use]
-extern crate serde_derive;
-#[cfg(feature = "serialize")]
-extern crate serde;
-
 mod code_pair;
 pub use crate::code_pair::CodePair;
 

--- a/src/line_weight.rs
+++ b/src/line_weight.rs
@@ -1,6 +1,6 @@
 /// Represents a line weight.
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct LineWeight {
     raw_value: i16,
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -21,7 +21,7 @@ use crate::objects::*;
 //                                                                  GeoMeshPoint
 //------------------------------------------------------------------------------
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct GeoMeshPoint {
     pub source: Point,
     pub destination: Point,
@@ -40,7 +40,7 @@ impl GeoMeshPoint {
 //                                                             MLineStyleElement
 //------------------------------------------------------------------------------
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct MLineStyleElement {
     pub offset: f64,
     pub color: Color,

--- a/src/point.rs
+++ b/src/point.rs
@@ -2,7 +2,7 @@ use crate::{CodePair, DxfError, DxfResult};
 
 /// Represents a simple point in Cartesian space.
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Point {
     /// The X value of the point.
     pub x: f64,

--- a/src/section_geometry_settings.rs
+++ b/src/section_geometry_settings.rs
@@ -3,7 +3,7 @@ use crate::{CodePair, Color, DxfResult};
 use crate::code_pair_put_back::CodePairPutBack;
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct SectionGeometrySettings {
     pub section_type: i32,
     pub geometry_count: i32,

--- a/src/section_type_settings.rs
+++ b/src/section_type_settings.rs
@@ -4,7 +4,7 @@ use crate::code_pair_put_back::CodePairPutBack;
 use crate::helper_functions::*;
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct SectionTypeSettings {
     pub section_type: i32,
     pub is_generation_option: bool,

--- a/src/table_cell_style.rs
+++ b/src/table_cell_style.rs
@@ -5,7 +5,7 @@ use crate::helper_functions::*;
 
 /// Defines a style for a table's cell.
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct TableCellStyle {
     pub name: String,
     pub text_height: f64,

--- a/src/transformation_matrix.rs
+++ b/src/transformation_matrix.rs
@@ -1,6 +1,6 @@
 /// Applies a transformation to a point.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransformationMatrix {
     pub m11: f64,
     pub m12: f64,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -2,7 +2,7 @@ use crate::{CodePair, DxfError, DxfResult};
 
 /// Represents a simple vector in Cartesian space.
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vector {
     /// The X component of the vector.
     pub x: f64,

--- a/src/x_data.rs
+++ b/src/x_data.rs
@@ -22,7 +22,7 @@ const XDATA_LONG: i32 = 1071;
 
 /// Represents an application name and a collection of extended data.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct XData {
     pub application_name: String,
     pub items: Vec<XDataItem>,
@@ -30,7 +30,7 @@ pub struct XData {
 
 /// Represents a piece of extended data.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum XDataItem {
     Str(String),
     ControlGroup(Vec<XDataItem>),


### PR DESCRIPTION
Since the crate is using Rust edition 2018, we can use the macros directly without a `macro_use`.

The recommended way to use `serde_derive` now is to use the `derive` feature on the `serde` crate.