### PR TITLE
fix polyface mesh vertices not being applied

### DIFF
--- a/spec/EntitiesSpec.xml
+++ b/spec/EntitiesSpec.xml
@@ -493,7 +493,7 @@
     <Field Name="row_count" Code="71" Type="i16" DefaultValue="1" DisableWritingDefault="true" />
     <Field Name="column_spacing" Code="44" Type="f64" DefaultValue="0.0" DisableWritingDefault="true" />
     <Field Name="row_spacing" Code="45" Type="f64" DefaultValue="0.0" DisableWritingDefault="true" />
-    <Field Name="extrusion_direction" Code="210" Type="Vector" DefaultValue="Vector::z_axis()" CodeOverrides="210,220,230" MinVersion="R13" />
+    <Field Name="extrusion_direction" Code="210" Type="Vector" DefaultValue="Vector::z_axis()" CodeOverrides="210,220,230" MinVersion="R12" />
     <Field Name="__attributes_and_handles" Code="10" Type="(Attribute, Handle)" DefaultValue="vec![]" AllowMultiples="true" GenerateReader="false" GenerateWriter="false" />
     <WriteOrder>
       <WriteSpecificValue Code="100" Value='&amp;String::from("AcDbBlockReference")' MinVersion="R13" />

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -2878,7 +2878,27 @@ mod tests {
     }
 
     #[test]
-    fn write_insert_no_extrusion_on_r12() {
+    fn write_insert_no_extrusion_on_r11() {
+        let mut drawing = Drawing::new();
+        drawing.header.version = AcadVersion::R11;
+        let ins = Insert {
+            extrusion_direction: Vector::new(1.0, 2.0, 3.0),
+            ..Default::default()
+        };
+        let ent = Entity::new(EntityType::Insert(ins));
+        drawing.add_entity(ent);
+        assert_not_contains_pairs(
+            &drawing,
+            vec![
+                CodePair::new_f64(210, 1.0),
+                CodePair::new_f64(220, 2.0),
+                CodePair::new_f64(230, 3.0),
+            ],
+        );
+    }
+
+    #[test]
+    fn write_insert_extrusion_on_r12() {
         let mut drawing = Drawing::new();
         drawing.header.version = AcadVersion::R12;
         let ins = Insert {
@@ -2887,7 +2907,7 @@ mod tests {
         };
         let ent = Entity::new(EntityType::Insert(ins));
         drawing.add_entity(ent);
-        assert_not_contains_pairs(
+        assert_contains_pairs(
             &drawing,
             vec![
                 CodePair::new_f64(210, 1.0),

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1515,7 +1515,7 @@ impl Entity {
         }
         pairs.push(CodePair::new_i16(70, v.flags as i16));
         pairs.push(CodePair::new_f64(50, v.curve_fit_tangent_direction));
-        if version >= AcadVersion::R13 {
+        if version >= AcadVersion::R12 {
             if v.polyface_mesh_vertex_index1 != 0 {
                 pairs.push(CodePair::new_i16(71, v.polyface_mesh_vertex_index1 as i16));
             }
@@ -1572,7 +1572,13 @@ impl Entity {
                 for (v, vertex_handle) in &poly.__vertices_and_handles {
                     let mut v = v.clone();
                     v.set_is_3d_polyline_vertex(poly.is_3d_polyline());
-                    v.set_is_3d_polygon_mesh(poly.is_3d_polygon_mesh());
+                    if v.polyface_mesh_vertex_index1 == 0
+                        && v.polyface_mesh_vertex_index2 == 0
+                        && v.polyface_mesh_vertex_index3 == 0
+                        && v.polyface_mesh_vertex_index4 == 0
+                    {
+                        v.set_is_3d_polygon_mesh(poly.is_3d_polygon_mesh());
+                    }
                     let v = Entity {
                         common: EntityCommon {
                             handle: *vertex_handle,


### PR DESCRIPTION
This is to fix Polylines that are polyfaces not getting their indices applied to the vertices.

It also lowers support for polyfaces from R13 to R12. R12 spec supports polyfaces.