### PR TITLE
fixing all open clippy warnings

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = ["AutoCAD", "PostScript", ".."]
+doc-valid-idents = ["AutoCAD", "PostScript", "..", "DesignCenter", "PlotStyle", "DWFx"]

--- a/src/block.rs
+++ b/src/block.rs
@@ -37,7 +37,7 @@ pub struct Block {
     pub entities: Vec<Entity>,
     /// Extension data groups.
     pub extension_data_groups: Vec<ExtensionGroup>,
-    /// XData.
+    /// `XData`.
     pub x_data: Vec<XData>,
 }
 

--- a/src/dxb_reader.rs
+++ b/src/dxb_reader.rs
@@ -271,7 +271,7 @@ impl<T: Read> DxbReader<T> {
     fn wrap_common_values(&self, specific: EntityType) -> Entity {
         let mut entity = Entity::new(specific);
         entity.common.color = self.current_color.clone();
-        entity.common.layer = self.layer_name.clone();
+        entity.common.layer.clone_from(&self.layer_name);
         entity
     }
     fn read_null_terminated_string(&mut self) -> DxfResult<String> {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1743,7 +1743,7 @@ mod tests {
             common: Default::default(),
             specific: EntityType::Line(Default::default()),
         };
-        ent.common.layer = "some-layer".to_owned();
+        "some-layer".clone_into(&mut ent.common.layer);
         drawing.add_entity(ent);
         assert_contains_pairs(
             &drawing,
@@ -1764,7 +1764,7 @@ mod tests {
             common: Default::default(),
             specific: EntityType::Line(Default::default()),
         };
-        ent.common.layer = "some-layer".to_owned();
+        "some-layer".clone_into(&mut ent.common.layer);
         drawing.add_entity(ent);
         assert_contains_pairs(
             &drawing,

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -612,7 +612,7 @@ pub mod tests {
         assert!(actual.contains(&contents));
     }
 
-    fn try_find_index<T>(superset: &Vec<T>, subset: &Vec<T>) -> Option<usize>
+    fn try_find_index<T>(superset: &[T], subset: &[T]) -> Option<usize>
     where
         T: PartialEq,
     {
@@ -634,7 +634,7 @@ pub mod tests {
         None
     }
 
-    pub fn assert_vec_contains<T>(actual: &Vec<T>, expected: &Vec<T>)
+    pub fn assert_vec_contains<T>(actual: &[T], expected: &[T])
     where
         T: PartialEq,
     {

--- a/src/misc_tests/encoding.rs
+++ b/src/misc_tests/encoding.rs
@@ -511,7 +511,7 @@ fn round_trip_thumbnail(thumbnail: image::DynamicImage) -> image::DynamicImage {
     let drawing_pairs = drawing.code_pairs().unwrap();
     assert_vec_contains(
         &drawing_pairs,
-        &vec![
+        &[
             CodePair::new_str(0, "SECTION"),
             CodePair::new_str(2, "THUMBNAILIMAGE"),
         ],

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -73,7 +73,7 @@ fn read_thumbnail_bytes_from_code_pairs(iter: &mut CodePairPutBack) -> DxfResult
     Ok(Some(data))
 }
 
-fn update_thumbnail_data_offset_in_situ(data: &mut Vec<u8>) -> DxfResult<bool> {
+fn update_thumbnail_data_offset_in_situ(data: &mut [u8]) -> DxfResult<bool> {
     // calculate the image data offset
     let dib_header_size = read_i32(data, FILE_HEADER_LENGTH)? as usize;
 
@@ -240,7 +240,7 @@ fn test_get_u32() {
     assert_eq!(0x12345678, value);
 }
 
-fn set_i32(data: &mut Vec<u8>, offset: usize, value: i32) -> DxfResult<()> {
+fn set_i32(data: &mut [u8], offset: usize, value: i32) -> DxfResult<()> {
     let expected_length = offset + 4;
     if data.len() < expected_length {
         return Err(DxfError::UnexpectedEndOfInput);


### PR DESCRIPTION
Hoping that I've done this right and these small changes are welcome, but since I was looking at the dependencies I decided to just go ahead and fix all currently open clippy warnings. Let me know if anything needs to be adjusted or if I did anything wrong!