### PR TITLE
fix(DataTable)-77: Index out of bounds

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -62,7 +62,7 @@ impl MLineStyleElement {
 //------------------------------------------------------------------------------
 impl DataTable {
     pub(crate) fn set_value(&mut self, row: usize, col: usize, val: DataTableValue) {
-        if row <= self.row_count && col <= self.column_count {
+        if row < self.row_count && col < self.column_count {
             self.values[row][col] = Some(val);
         }
     }


### PR DESCRIPTION
Changes:
- When indexing DataTable, it needs to be within the bounds.