### PR TITLE
Add `Debug` and `Clone` to Drawing and others

### DIFF
--- a/build/header_generator.rs
+++ b/build/header_generator.rs
@@ -60,6 +60,7 @@ use self::uuid::Uuid;
 fn generate_struct(fun: &mut String, element: &Element) {
     let mut seen_fields = HashSet::new();
     fun.push_str("/// Contains common properties for the DXF file.\n");
+    fun.push_str("#[derive(Debug, Clone)]\n");
     fun.push_str(
         "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
     );

--- a/build/table_generator.rs
+++ b/build/table_generator.rs
@@ -56,7 +56,7 @@ fn generate_table_items(fun: &mut String, element: &Element) {
     for table in &element.children {
         let mut seen_fields = HashSet::new();
         let table_item = &table.children[0];
-        fun.push_str("#[derive(Debug)]\n");
+        fun.push_str("#[derive(Debug, Clone)]\n");
         fun.push_str(
             "#[cfg_attr(feature = \"serialize\", derive(serde::Serialize, serde::Deserialize))]\n",
         );

--- a/src/class.rs
+++ b/src/class.rs
@@ -5,7 +5,7 @@ use crate::enums::*;
 use crate::helper_functions::*;
 
 /// Represents an application-defined class whose instances are `Block`s, `Entity`s, and `Object`s.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Class {
     /// Class DXF record name.

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -39,6 +39,7 @@ use std::path::Path;
 pub(crate) const AUTO_REPLACE_HANDLE: Handle = Handle(0xFFFF_FFFF_FFFF_FFFF);
 
 /// Represents a DXF drawing.
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Drawing {
     /// The drawing's header.  Contains various drawing-specific values and settings.


### PR DESCRIPTION
Added the traits `Debug` and `Clone` to the [`Drawing`] struct as well as [`Header`], [`Class`], and anything using `build/table_generator.rs`.

This is purely for the ability to inspect and move Drawings around during development.

I could see this being a feature if this isn't desired to be default behavior as well.