### PR TITLE
deps: Don't use default-features on `image`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.3.4"
 chrono = { version= "0.4.19", features = ["serde"] }
 encoding_rs = "0.8.26"
 enum_primitive = "0.1.1"
-image = "0.25.1"
+image = { version = "0.25.1", default-features = false, features = ["bmp"] }
 itertools = "0.13.0"
 num = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
This brings in a lot of image formats (and a lot of extra dependencies) that aren't needed here.

This reduces the build time substantially as well.