### PR TITLE
Remove most uses of `extern crate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ dxf = { version = "0.5.0", features = ["serialize"] }
 > Note that `serde` support is intended to aid in debugging and since the serialized format is heavily
 dependent on the layout of the structures, it may change at any time.
 
-And finally add:
-
-``` rust
-extern crate dxf;
-```
-
 # Documentation
 
 See the documentation [here](https://docs.rs/dxf/) on docs.rs.

--- a/build/entity_generator.rs
+++ b/build/entity_generator.rs
@@ -1,5 +1,4 @@
-extern crate xmltree;
-use self::xmltree::Element;
+use xmltree::Element;
 
 use crate::ExpectedType;
 
@@ -39,8 +38,9 @@ use crate::helper_functions::*;
 use crate::tables::*;
 use crate::x_data;
 
+use enum_primitive::FromPrimitive;
+
 use crate::enums::*;
-use crate::enum_primitive::FromPrimitive;
 use crate::objects::*;
 ".trim_start());
     fun.push('\n');

--- a/build/header_generator.rs
+++ b/build/header_generator.rs
@@ -1,5 +1,4 @@
-extern crate xmltree;
-use self::xmltree::Element;
+use xmltree::Element;
 
 use crate::ExpectedType;
 
@@ -32,15 +31,13 @@ use crate::{
 use crate::helper_functions::*;
 
 use crate::enums::*;
-use crate::enum_primitive::FromPrimitive;
+use enum_primitive::FromPrimitive;
 
 use std::time::Duration;
 
-extern crate chrono;
-use self::chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Local, Utc};
 
-extern crate uuid;
-use self::uuid::Uuid;
+use uuid::Uuid;
 ".trim_start());
     generate_struct(&mut fun, &element);
 

--- a/build/object_generator.rs
+++ b/build/object_generator.rs
@@ -1,5 +1,4 @@
-extern crate xmltree;
-use self::xmltree::Element;
+use xmltree::Element;
 
 use crate::ExpectedType;
 
@@ -46,11 +45,10 @@ use crate::x_data;
 
 use crate::entities::*;
 use crate::enums::*;
-use crate::enum_primitive::FromPrimitive;
+use enum_primitive::FromPrimitive;
 use std::collections::HashMap;
 
-extern crate chrono;
-use self::chrono::{DateTime, Local};
+use chrono::{DateTime, Local};
 ".trim_start());
     fun.push('\n');
     generate_base_object(&mut fun, &element);

--- a/build/table_generator.rs
+++ b/build/table_generator.rs
@@ -1,5 +1,4 @@
-extern crate xmltree;
-use self::xmltree::Element;
+use xmltree::Element;
 
 use crate::ExpectedType;
 
@@ -16,8 +15,6 @@ pub fn generate_tables(generated_dir: &Path) {
     let mut fun = String::new();
     fun.push_str("
 // The contents of this file are automatically generated and should not be modified directly.  See the `build` directory.
-
-extern crate itertools;
 
 use crate::{
     CodePair,
@@ -41,7 +38,7 @@ use crate::extension_data;
 use crate::x_data;
 
 use crate::enums::*;
-use crate::enum_primitive::FromPrimitive;
+use enum_primitive::FromPrimitive;
 ".trim_start());
     fun.push('\n');
     generate_table_items(&mut fun, &element);

--- a/build/test_helper_generator.rs
+++ b/build/test_helper_generator.rs
@@ -1,5 +1,4 @@
-extern crate xmltree;
-use self::xmltree::Element;
+use xmltree::Element;
 
 use crate::xml_helpers::*;
 

--- a/build/xml_helpers.rs
+++ b/build/xml_helpers.rs
@@ -1,7 +1,6 @@
-extern crate xmltree;
-use self::xmltree::Element;
 use crate::other_helpers::*;
 use crate::ExpectedType;
+use xmltree::Element;
 
 pub fn attr(element: &Element, name: &str) -> String {
     match element.attributes.get(name) {

--- a/dxf2json/src/main.rs
+++ b/dxf2json/src/main.rs
@@ -1,7 +1,3 @@
-extern crate dxf;
-extern crate serde;
-extern crate serde_json;
-
 use dxf::Drawing;
 use std::env;
 use std::fs::File;

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,5 +1,3 @@
-extern crate dxf;
-
 mod block_examples;
 mod line_type_examples;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -305,6 +305,7 @@ mod tests {
     use crate::enums::*;
     use crate::helper_functions::tests::*;
     use crate::*;
+    use float_cmp::approx_eq;
 
     fn read_blocks_section(content: Vec<CodePair>) -> Drawing {
         let mut pairs = vec![

--- a/src/code_pair.rs
+++ b/src/code_pair.rs
@@ -1,9 +1,7 @@
-extern crate byteorder;
-
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
-use self::byteorder::{BigEndian, ByteOrder};
+use byteorder::{BigEndian, ByteOrder};
 
 use crate::{CodePairValue, DxfError, DxfResult, Handle};
 

--- a/src/code_pair_writer.rs
+++ b/src/code_pair_writer.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 
-extern crate byteorder;
-use self::byteorder::{LittleEndian, WriteBytesExt};
+use byteorder::{LittleEndian, WriteBytesExt};
 
 use crate::code_pair_value::{escape_control_characters, escape_unicode_to_ascii};
 use crate::enums::AcadVersion;

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -1,8 +1,6 @@
-extern crate encoding_rs;
-use self::encoding_rs::Encoding;
+use encoding_rs::Encoding;
 
-extern crate image;
-use self::image::DynamicImage;
+use image::DynamicImage;
 
 use crate::code_pair_put_back::CodePairPutBack;
 use crate::drawing_item::{DrawingItem, DrawingItemMut};

--- a/src/dxb_writer.rs
+++ b/src/dxb_writer.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 
-extern crate byteorder;
-use self::byteorder::{LittleEndian, WriteBytesExt};
+use byteorder::{LittleEndian, WriteBytesExt};
 
 use crate::{Drawing, DxfResult};
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1628,6 +1628,7 @@ mod tests {
     use crate::helper_functions::tests::*;
     use crate::objects::*;
     use crate::*;
+    use float_cmp::approx_eq;
 
     fn read_entity(entity_type: &str, body: Vec<CodePair>) -> Entity {
         let mut pairs = vec![CodePair::new_str(0, entity_type)];

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,3 @@
-extern crate num;
-
 use crate::{DxfError, DxfResult};
 use std::fmt;
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -76,6 +76,7 @@ mod tests {
     use crate::enums::*;
     use crate::helper_functions::tests::*;
     use crate::*;
+    use float_cmp::approx_eq;
     use std::time::Duration;
 
     #[test]

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -3,18 +3,14 @@ use std::io;
 use std::io::Read;
 use std::time::Duration as StdDuration;
 
-extern crate byteorder;
-use self::byteorder::{ByteOrder, LittleEndian};
+use byteorder::{ByteOrder, LittleEndian};
 
-extern crate chrono;
-use self::chrono::prelude::*;
-use self::chrono::Duration as ChronoDuration;
+use chrono::prelude::*;
+use chrono::Duration as ChronoDuration;
 
-extern crate encoding_rs;
-use self::encoding_rs::Encoding;
+use encoding_rs::Encoding;
 
-extern crate uuid;
-use self::uuid::Uuid;
+use uuid::Uuid;
 
 use enum_primitive::FromPrimitive;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,6 @@
 //! > Note that `serde` support is intended to aid in debugging and since the serialized format is heavily
 //! dependent on the layout of the structures, it may change at any time.
 //!
-//! And finally add:
-//!
-//! ``` rust
-//! extern crate dxf;
-//! ```
-//!
 //! # Examples
 //!
 //! Open a DXF file from disk:
@@ -115,13 +109,8 @@
 
 #![warn(clippy::doc_markdown)]
 
-extern crate encoding_rs;
-
 #[macro_use]
 extern crate enum_primitive;
-
-extern crate image;
-extern crate itertools;
 
 mod code_pair;
 pub use crate::code_pair::CodePair;
@@ -228,9 +217,5 @@ mod object_iter;
 
 #[cfg(test)]
 include!(concat!(env!("OUT_DIR"), "/generated/tests/mod.rs"));
-
-#[cfg(test)]
-#[macro_use]
-extern crate float_cmp;
 
 mod misc_tests;

--- a/src/misc_tests/encoding.rs
+++ b/src/misc_tests/encoding.rs
@@ -6,8 +6,7 @@ use crate::*;
 use std::io::{BufReader, Cursor, Seek, SeekFrom};
 use std::str::from_utf8;
 
-extern crate image;
-use self::image::{DynamicImage, GenericImageView};
+use image::{DynamicImage, GenericImageView};
 
 #[test]
 fn read_string_with_control_characters() {

--- a/src/misc_tests/integration.rs
+++ b/src/misc_tests/integration.rs
@@ -8,7 +8,6 @@ use std::process::Command;
 use std::thread::panicking;
 use std::time::SystemTime;
 
-extern crate glob;
 use glob::glob;
 
 struct Oda {

--- a/src/object.rs
+++ b/src/object.rs
@@ -4,8 +4,7 @@ use enum_primitive::FromPrimitive;
 use itertools::Itertools;
 use std::ops::Add;
 
-extern crate chrono;
-use self::chrono::Duration;
+use chrono::Duration;
 
 use crate::{
     CodePair, Color, DataTableValue, DxfError, DxfResult, Point, SectionTypeSettings,

--- a/src/table.rs
+++ b/src/table.rs
@@ -67,6 +67,7 @@ mod tests {
     use crate::objects::*;
     use crate::tables::*;
     use crate::*;
+    use float_cmp::approx_eq;
 
     fn read_table(table_name: &str, value_pairs: Vec<CodePair>) -> Drawing {
         let mut pairs = vec![


### PR DESCRIPTION
This leaves only one for `enum_primitive` as that needs further work (and ideally switching to a maintained crate that does that sort of thing).