### PR TITLE
reading an invalid f64 now returns 0.0

### DIFF
--- a/src/dxb_reader.rs
+++ b/src/dxb_reader.rs
@@ -296,9 +296,13 @@ impl<T: Read> DxbReader<T> {
         Ok(value)
     }
     fn read_f(&mut self) -> DxfResult<f64> {
-        let value = read_f64(&mut self.reader)?;
+        let value = read_f64(&mut self.reader);
+        if value.is_err() {
+            self.advance_offset(8);
+            return Ok(0.0);
+        }
         self.advance_offset(8);
-        Ok(value)
+        Ok(value.unwrap())
     }
     fn read_n(&mut self) -> DxfResult<f64> {
         if self.is_integer_mode {


### PR DESCRIPTION
Related to [this issue](https://github.com/ixmilia/dxf-rs/issues/86)

To handle the cases "NaN.0", "0.NaN", and any other floats that are valid in dxf files and invalid in rust, I changed it so that any invalid f64 would become 0.0 when reading.

it's not the best approach, I know. but it's better than the program crashing, which is what I need