### PR TITLE
the read_f function now returns value.or(Ok(0.0)) instead of panicing when the value is invalid

### DIFF
--- a/src/dxb_reader.rs
+++ b/src/dxb_reader.rs
@@ -297,12 +297,8 @@ impl<T: Read> DxbReader<T> {
     }
     fn read_f(&mut self) -> DxfResult<f64> {
         let value = read_f64(&mut self.reader);
-        if value.is_err() {
-            self.advance_offset(8);
-            return Ok(0.0);
-        }
         self.advance_offset(8);
-        Ok(value.unwrap())
+        Ok(value.or::<f64>(Ok(0.0)).unwrap())
     }
     fn read_n(&mut self) -> DxfResult<f64> {
         if self.is_integer_mode {

--- a/src/dxb_reader.rs
+++ b/src/dxb_reader.rs
@@ -296,9 +296,13 @@ impl<T: Read> DxbReader<T> {
         Ok(value)
     }
     fn read_f(&mut self) -> DxfResult<f64> {
-        let value = read_f64(&mut self.reader)?;
+        let value = read_f64(&mut self.reader);
+        if value.is_err() {
+            self.advance_offset(8);
+            return Ok(0.0);
+        }
         self.advance_offset(8);
-        Ok(value)
+        Ok(value.unwrap())
     }
     fn read_n(&mut self) -> DxfResult<f64> {
         if self.is_integer_mode {


### PR DESCRIPTION
related to this pull request: https://github.com/ixmilia/dxf-rs/pull/87