### PR TITLE
Fix `clippy::or_then_unwrap` lint

### DIFF
--- a/src/dxb_reader.rs
+++ b/src/dxb_reader.rs
@@ -298,7 +298,7 @@ impl<T: Read> DxbReader<T> {
     fn read_f(&mut self) -> DxfResult<f64> {
         let value = read_f64(&mut self.reader);
         self.advance_offset(8);
-        Ok(value.or::<f64>(Ok(0.0)).unwrap())
+        Ok(value.unwrap_or(0.0))
     }
     fn read_n(&mut self) -> DxfResult<f64> {
         if self.is_integer_mode {


### PR DESCRIPTION
This code is more concise and easier to read.