### PR TITLE
feat: add a method to read from bytes, and add a test case for that

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -150,6 +150,15 @@ impl Drawing {
     pub fn load_file(path: impl AsRef<Path>) -> DxfResult<Drawing> {
         Drawing::load_file_with_encoding(path, encoding_rs::WINDOWS_1252)
     }
+
+    /// Loads a `Drawing` from a bytes array
+    pub fn load_from_bytes(bytes:  &[u8]) -> DxfResult<Drawing> {
+        // Using bufreader like this provides no advantages, its just a convinient way to conform with
+        // the existing apis
+        let mut buf_reader = BufReader::new(bytes);
+        Drawing::load(&mut buf_reader)
+    }
+
     /// Loads a `Drawing` from disk, using a `BufReader` with the specified text encoding.
     pub fn load_file_with_encoding(
         path: impl AsRef<Path>,

--- a/src/misc_tests/encoding.rs
+++ b/src/misc_tests/encoding.rs
@@ -291,6 +291,21 @@ fn read_binary_file() {
 }
 
 #[test]
+fn read_bytes(){
+    let bytes = std::fs::read("./src/misc_tests/diamond-bin.dxf").unwrap();
+    let drawing =unwrap_drawing(Drawing::load_from_bytes(bytes.as_ref()));
+    let entities = drawing.entities().collect::<Vec<_>>();
+    assert_eq!(12, entities.len());
+    match entities[0].specific {
+        EntityType::Line(ref line) => {
+            assert_eq!(Point::new(45.0, 45.0, 0.0), line.p1);
+            assert_eq!(Point::new(45.0, -45.0, 0.0), line.p2);
+        }
+        _ => panic!("expected a line"),
+    }
+}
+
+#[test]
 fn read_binary_file_post_r13() {
     // post R13 binary files have 2 byte codes and single byte booleans
     let data = vec![


### PR DESCRIPTION
This is just a quick implementation that wraps a `u8` slice with a reader and uses that. LMK if you want me to drop this and do it another way