### PR TITLE
fix overwrite polyface mesh Vertex flags

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1577,7 +1577,9 @@ impl Entity {
                         && v.polyface_mesh_vertex_index3 == 0
                         && v.polyface_mesh_vertex_index4 == 0
                     {
-                        v.set_is_3d_polygon_mesh(poly.is_3d_polygon_mesh());
+                        v.set_is_3d_polygon_mesh(
+                            v.is_3d_polygon_mesh() | poly.is_3d_polygon_mesh(),
+                        );
                     }
                     let v = Entity {
                         common: EntityCommon {


### PR DESCRIPTION
fixes #96 

When creating a polyface mesh the reference says that positions are given by a Vertex with both the 128 & 64 flag bit set, while face-indices are given by a Vertex with just the 128 bit set. The 16 bit is never set for polyface mesh vertices. 

When adding vertex pairs to a polyface mesh polyline the 64 bit was unconditionally getting unset based on the 16 bit. This patch fixes the issue by also considering the current value of the 64 bit.